### PR TITLE
Switch omp to wrapped mode

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -3,7 +3,6 @@
 (library
  ((name migrate_parsetree)
   (public_name ocaml-migrate-parsetree)
-  (wrapped false)
   (libraries (compiler-libs.common result))
   (flags (:standard -open Result))
   (modules (:standard \ migrate_parsetree_driver_main))


### PR DESCRIPTION
All the modules are accessible from the toplevel anyway. I wonder why it was unwrapped in the first place.