### PR TITLE
Add --print-transformations

### DIFF
--- a/ocaml-migrate-parsetree.opam
+++ b/ocaml-migrate-parsetree.opam
@@ -15,6 +15,7 @@ build: [
 ]
 depends: [
   "result"
+  "ppx_derivers"
   "dune" {build}
 ]
 available: ocaml-version >= "4.02.0"

--- a/src/jbuild
+++ b/src/jbuild
@@ -4,7 +4,7 @@
  ((name migrate_parsetree)
   (public_name ocaml-migrate-parsetree)
   (wrapped false)
-  (libraries (compiler-libs.common result))
+  (libraries (compiler-libs.common result ppx_derivers))
   (flags (:standard -open Result))
   (modules (:standard \ migrate_parsetree_driver_main))
   (preprocess (action (run ${exe:../tools/pp.exe} ${read:ast-version} ${<})))

--- a/src/migrate_parsetree_driver.ml
+++ b/src/migrate_parsetree_driver.ml
@@ -434,10 +434,20 @@ let process_file ~config ~output ~output_mode ~embed_errors file =
     ()
 
 let print_transformations () =
+  let print_group name = function
+    | [] -> ()
+    | names ->
+        Printf.printf "%s:\n" name;
+        List.iter (Printf.printf "%s\n") names
+  in
   all_rewriters ()
-  |> List.iter (fun r ->
-      rewriter_group_names r
-      |> List.iter (Printf.printf "%s\n"))
+  |> List.map rewriter_group_names
+  |> List.concat
+  |> print_group "Registered Transformations";
+  Ppx_derivers.derivers ()
+  |> List.map (fun (x, _) -> x)
+  |> print_group "Registered Derivers"
+
 
 let run_as_standalone_driver () =
   let request_print_transformations = ref false in


### PR DESCRIPTION
Like in ppxlib, this will print all the currently registered transformations.

Also, what do you think about printing the currently registered derivers? This will be quite useful but will come at the cost of depending on ppx_derivers. However, that package is pretty fundamental to ppx, so it doesn't seem like an issue.