### PR TITLE
Make ocamlbuild_plugin optional

### DIFF
--- a/ocamlbuild_plugin/jbuild
+++ b/ocamlbuild_plugin/jbuild
@@ -2,6 +2,7 @@
  ((name        migrate_parsetree_ocamlbuild)
   (public_name ocaml-migrate-parsetree-ocamlbuild)
   (synopsis    "ocamlbuild plugin for automatically generating ppx dirvers")
+  (optional)
   (libraries   (ocamlbuild))))
 
 (jbuild_version 1)


### PR DESCRIPTION
This one-liner simply makes the building of `ocamlbuild_plugin` optional, which allows to vendor `ocaml-migrate-parsetree` without `ocamlbuild`.