### PR TITLE
Windows: Fix 'output_value: not a binary channel' when writing the AST to stdout

### DIFF
--- a/src/migrate_parsetree_ast_io.ml
+++ b/src/migrate_parsetree_ast_io.ml
@@ -88,6 +88,7 @@ let decompose_ast = function
 
 let to_channel oc (filename : filename) x =
   let magic_number, payload = decompose_ast x in
+  set_binary_mode_out oc true;
   output_string oc magic_number;
   output_value oc filename;
   output_value oc payload


### PR DESCRIPTION
__Issue:__ I was building the latest `ppx_deriving_yojson` on Windows, and hit this error:
```
  # esy-build-package: building: @opam/ppx_deriving_yojson@opam:3.3
    # esy-build-package: pwd: C:\Users\bryph\.esy\3_\b\opam__s__ppx__deriving__yojson-opam__c__3.3-f1cb9869
    # esy-build-package: running: "dune" "build" "-p" "ppx_deriving_yojson" "-j" "4"
         ppxfind src/ppx_deriving_yojson.pp.ml (exit 2)
    (cd _build/default && C:\Users\bryph\.esy\3_\i\opam__s__ppxfind-opam__c__1.2-3fa788d0\bin\ppxfind.exe -legacy ppx_tools.metaquot --as-pp src/ppx_deriving_yojson.ml) > _build/default/src/ppx_deriving_yojson.pp.ml
    Fatal error: exception Failure("output_value: not a binary channel")
    error: command failed: "dune" "build" "-p" "ppx_deriving_yojson" "-j" "4" (exited with 1)
    esy-build-package: exiting with errors above...

  building @opam/ppx_deriving_yojson@opam:3.3@d196be77
```

__Defect:__ `ocaml-migrate-parsetree` uses `output_value` without ensuring the channel is on binary m ode. On OSX/Linux, this is fine, because binary mode is the default. However, on Windows, we need to ensure the channel is in binary mode for either the `stdout` or file case. 

The reason I hit this now is because `ppx_deriving_yojson` depends on `ppxfind` in its latest release, which depends on `ocaml-migrate-parsetree`.

__Fix:__ Call `set_binary_mode_out oc true` prior to using the marshalling calls. This is a no-op on OSX/Linux, but will ensure the channel is in the correct mode on Windows.

cc @dra27 