### PR TITLE
Ensure stdout is in binary mode on Windows for --dump-ast

### DIFF
--- a/src/migrate_parsetree_ast_io.ml
+++ b/src/migrate_parsetree_ast_io.ml
@@ -88,7 +88,6 @@ let decompose_ast = function
 
 let to_channel oc (filename : filename) x =
   let magic_number, payload = decompose_ast x in
-  set_binary_mode_out oc true;
   output_string oc magic_number;
   output_value oc filename;
   output_value oc payload

--- a/src/migrate_parsetree_driver.ml
+++ b/src/migrate_parsetree_driver.ml
@@ -371,9 +371,14 @@ let load_file file =
       | Intf fn ->
         (fn, Intf (Parse.interface lexbuf)))
 
-let with_output output ~f =
+let with_output ?bin output ~f =
   match output with
-  | None -> f stdout
+  | None ->
+      begin match bin with
+      | Some bin -> set_binary_mode_out stdout bin
+      | None -> ()
+      end;
+      f stdout
   | Some fn -> with_file_out fn ~f
 
 type output_mode =
@@ -416,7 +421,7 @@ let process_file ~config ~output ~output_mode ~embed_errors file =
   in
   match output_mode with
   | Dump_ast ->
-    with_output output ~f:(fun oc ->
+    with_output ~bin:true output ~f:(fun oc ->
       let ast =
         match ast with
         | Intf (_, sg) -> Ast_io.Intf ((module OCaml_current), sg)


### PR DESCRIPTION
The fix proposed in #57 works, but forcing channels to binary mode isn't always a good idea, because you can't at present restore them to whatever they were before. This alternate fix hopefully deals with the underlying problem.

@bryphe does this still fix the build?