### PR TITLE
opam: add "with OCaml linking exception" to match LICENSE.md

### DIFF
--- a/ocaml-migrate-parsetree.opam
+++ b/ocaml-migrate-parsetree.opam
@@ -4,7 +4,7 @@ authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
   "Jérémie Dimino <jeremie@dimino.org>"
 ]
-license: "LGPL-2.1"
+license: "LGPL-2.1 with OCaml linking exception"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"


### PR DESCRIPTION
The `LICENSE.md` file seems to be the LGPL-2.1 with the OCaml linking exception.

Looking around in ocaml/opam-repository the standard opam `license` description in this case seems to be "LGPL-2.1+ with OCaml linking exception".

I noticed this discrepancy while using https://fossa.com to enumerate the licenses of the dependencies of https://github.com/moby/vpnkit 