### PR TITLE
Fix compilation of bin/ocaml_migrate_parsetree.ml

### DIFF
--- a/bin/ocaml_migrate_parsetree.ml
+++ b/bin/ocaml_migrate_parsetree.ml
@@ -3,6 +3,9 @@ let usage_msg =
   Printf.sprintf "Usage: %s <input-ast> [-to-ocaml40x <output-ast>]"
     Sys.argv.(0)
 
+type to_version =
+  To : 'a Migrate_parsetree.Versions.ocaml_version -> to_version
+
 let conversions = ref []
 let input = ref ""
 
@@ -17,21 +20,21 @@ let () =
   in
   let arg_spec = [
     (*$ foreach_version (fun suffix version ->
-          printf "(\"-to-ocaml%s\", Arg.String (add Migrate_parsetree.OCaml_%s),\n" suffix suffix;
+          printf "(\"-to-ocaml%s\", Arg.String (add (To Migrate_parsetree.OCaml_%s)),\n" suffix suffix;
           printf "\"<filename> Produce an ast valid for OCaml %s in <filename>\");\n" version;
         )
     *)
-    ("-to-ocaml402", Arg.String (add Migrate_parsetree.OCaml_402),
+    ("-to-ocaml402", Arg.String (add (To Migrate_parsetree.Versions.ocaml_402)),
      "<filename> Produce an ast valid for OCaml 4.02 in <filename>");
-    ("-to-ocaml403", Arg.String (add Migrate_parsetree.OCaml_403),
+    ("-to-ocaml403", Arg.String (add (To Migrate_parsetree.Versions.ocaml_403)),
      "<filename> Produce an ast valid for OCaml 4.03 in <filename>");
-    ("-to-ocaml404", Arg.String (add Migrate_parsetree.OCaml_404),
+    ("-to-ocaml404", Arg.String (add (To Migrate_parsetree.Versions.ocaml_404)),
      "<filename> Produce an ast valid for OCaml 4.04 in <filename>");
-    ("-to-ocaml405", Arg.String (add Migrate_parsetree.OCaml_405),
+    ("-to-ocaml405", Arg.String (add (To Migrate_parsetree.Versions.ocaml_405)),
      "<filename> Produce an ast valid for OCaml 4.05 in <filename>");
-    ("-to-ocaml406", Arg.String (add Migrate_parsetree.OCaml_406),
+    ("-to-ocaml406", Arg.String (add (To Migrate_parsetree.Versions.ocaml_406)),
      "<filename> Produce an ast valid for OCaml 4.06 in <filename>");
-    ("-to-ocaml407", Arg.String (add Migrate_parsetree.OCaml_407),
+    ("-to-ocaml407", Arg.String (add (To Migrate_parsetree.Versions.ocaml_407)),
      "<filename> Produce an ast valid for OCaml 4.07 in <filename>");
     (*$*)
   ] in
@@ -42,29 +45,51 @@ let () =
   );
   let (src_filename, ast) =
     let ic = open_in_bin !input in
-    match Migrate_parsetree.from_channel ic with
-    | exception (Migrate_parsetree.Unknown_magic_number number) ->
+    let result =
+      try
+        Migrate_parsetree.Ast_io.from_channel ic
+      with exn ->
+        close_in ic;
+        raise exn
+    in
+    close_in ic;
+    match result with
+    | Error (Unknown_version number) ->
       Printf.eprintf "Input file has unknown magic number: %s\n" number;
-      close_in ic;
       exit 1
-    | exception exn -> close_in ic; raise exn
-    | ast -> close_in ic; ast
+    | Error (Not_a_binary_ast _) ->
+      Printf.eprintf "Input file is not a binary AST\n";
+      exit 1
+    | Ok ast -> ast
   in
-  Printf.printf "Ast of %S for OCaml %s\n"
-    src_filename (Migrate_parsetree.string_of_ocaml_version
-                    (Migrate_parsetree.ast_version ast));
-  List.iter (fun (version, dst_filename) ->
-      match
-        let ast' = Migrate_parsetree.migrate_to_version ast version in
-        let oc = open_out_bin dst_filename in
-        Migrate_parsetree.to_channel oc src_filename ast';
-        close_out_noerr oc
-      with
-      | () ->
-        Printf.printf "Successfully converted %S to OCaml %s in %S\n"
-          !input (Migrate_parsetree.string_of_ocaml_version version) dst_filename
-      | exception exn ->
-        Printf.eprintf "Failed to convert %S to OCaml %s in %S:\n%s%!\n"
-          !input (Migrate_parsetree.string_of_ocaml_version version) dst_filename
-          (Printexc.to_string exn)
-    ) (List.rev !conversions)
+  let version =
+    match ast with
+    | Impl ((module O), _) -> O.string_version
+    | Intf ((module O), _) -> O.string_version
+  in
+  Printf.printf "Ast of %S for OCaml %s\n" src_filename version;
+  List.iter (fun (To (module Dst), dst_filename) ->
+    let ast' : Migrate_parsetree.Ast_io.ast =
+      match ast with
+      | Impl ((module Src), src_impl) ->
+          let module Convert = Migrate_parsetree.Versions.Convert(Src)(Dst) in
+          let dst_impl = Convert.copy_structure src_impl in
+          (Impl ((module Dst), dst_impl))
+      | Intf ((module Src), src_sig) ->
+          let module Convert = Migrate_parsetree.Versions.Convert(Src)(Dst) in
+          let dst_sig = Convert.copy_signature src_sig in
+          (Intf ((module Dst), dst_sig))
+    in
+    match
+      let oc = open_out_bin dst_filename in
+      Migrate_parsetree.Ast_io.to_channel oc src_filename ast';
+      close_out_noerr oc
+    with
+    | () ->
+      Printf.printf "Successfully converted %S to OCaml %s in %S\n"
+        !input Dst.string_version dst_filename
+    | exception exn ->
+      Printf.eprintf "Failed to convert %S to OCaml %s in %S:\n%s%!\n"
+        !input Dst.string_version dst_filename
+        (Printexc.to_string exn)
+  ) (List.rev !conversions)


### PR DESCRIPTION
This PR fixes the compilation of "bin/ocaml_migrate_parsetree" which was causing `dune build @all` to fail.

I just fixed all the type errors and replace them with the new api; but I have not tested the resulting tool.

Maybe a simpler PR would have been to remove the tool ? Is it still useful ?