### PR TITLE
Some small tuning for 4.08

### DIFF
--- a/src/ast_408.ml
+++ b/src/ast_408.ml
@@ -28,29 +28,34 @@
          Actually run all lib-unix tests [4.08]
 *)
 
-module Int = struct
-  let to_string = string_of_int
-end
-module Misc = struct
-  module Stdlib = struct
-    module String = struct
-      include String
-      module Map = Map.Make (String)
-    end
+
+module Locally_redefined = struct
+
+  module Int = struct
+    let to_string = string_of_int
   end
-  let find_in_path = Misc.find_in_path
-  let find_in_path_uncap = Misc.find_in_path_uncap
-  type ref_and_value = R : 'a ref * 'a -> ref_and_value
-  let protect_refs =
-    let set_refs l = List.iter (fun (R (r, v)) -> r := v) l in
-    fun refs f ->
-      let backup = List.map (fun (R (r, _)) -> R (r, !r)) refs in
-      set_refs refs;
-      match f () with
-      | x           -> set_refs backup; x
-      | exception e -> set_refs backup; raise e
-  let may_map f o = match o with None -> None | Some v -> Some (f v)
+  module Misc = struct
+    module Stdlib = struct
+      module String = struct
+        include String
+        module Map = Map.Make (String)
+      end
+    end
+    let find_in_path = Misc.find_in_path
+    let find_in_path_uncap = Misc.find_in_path_uncap
+    type ref_and_value = R : 'a ref * 'a -> ref_and_value
+    let protect_refs =
+      let set_refs l = List.iter (fun (R (r, v)) -> r := v) l in
+      fun refs f ->
+        let backup = List.map (fun (R (r, _)) -> R (r, !r)) refs in
+        set_refs refs;
+        match f () with
+        | x           -> set_refs backup; x
+        | exception e -> set_refs backup; raise e
+    let may_map f o = match o with None -> None | Some v -> Some (f v)
+  end
 end
+open Locally_redefined
 
 module Location = Location
 module Longident = Longident

--- a/src/ast_408.ml
+++ b/src/ast_408.ml
@@ -29,33 +29,7 @@
 *)
 
 
-module Locally_redefined = struct
-
-  module Int = struct
-    let to_string = string_of_int
-  end
-  module Misc = struct
-    module Stdlib = struct
-      module String = struct
-        include String
-        module Map = Map.Make (String)
-      end
-    end
-    let find_in_path = Misc.find_in_path
-    let find_in_path_uncap = Misc.find_in_path_uncap
-    type ref_and_value = R : 'a ref * 'a -> ref_and_value
-    let protect_refs =
-      let set_refs l = List.iter (fun (R (r, v)) -> r := v) l in
-      fun refs f ->
-        let backup = List.map (fun (R (r, _)) -> R (r, !r)) refs in
-        set_refs refs;
-        match f () with
-        | x           -> set_refs backup; x
-        | exception e -> set_refs backup; raise e
-    let may_map f o = match o with None -> None | Some v -> Some (f v)
-  end
-end
-open Locally_redefined
+open Ast_408_helper
 
 module Location = Location
 module Longident = Longident

--- a/src/ast_408_helper.ml
+++ b/src/ast_408_helper.ml
@@ -1,0 +1,23 @@
+module Int = struct
+  let to_string = string_of_int
+end
+module Misc = struct
+  module Stdlib = struct
+    module String = struct
+      include String
+      module Map = Map.Make (String)
+    end
+  end
+  let find_in_path = Misc.find_in_path
+  let find_in_path_uncap = Misc.find_in_path_uncap
+  type ref_and_value = R : 'a ref * 'a -> ref_and_value
+  let protect_refs =
+    let set_refs l = List.iter (fun (R (r, v)) -> r := v) l in
+    fun refs f ->
+      let backup = List.map (fun (R (r, _)) -> R (r, !r)) refs in
+      set_refs refs;
+      match f () with
+      | x           -> set_refs backup; x
+      | exception e -> set_refs backup; raise e
+  let may_map f o = match o with None -> None | Some v -> Some (f v)
+end


### PR DESCRIPTION
- opening `Ast_408` should not shadow `Int` or `Misc`
- `[@a]` and `[@@a]` attribute on exceptions were equivalent pre 4.08. Now that there are not equivalent anymore, we should dispatch them when upgrading for 4.07 to 4.08. In particular, the `deprecated` attribute should be attached on the constructor (`[@deprecated ...]`), other attributes usually refer to the exception declaration (`[@@deriving sexp]`). (cf https://github.com/ocaml/ocaml/pull/1705)
- Order of floating doc comments in classes has been fixed in 4.08 by https://github.com/ocaml/ocaml/pull/1970. restore the order when upgrading from 4.07 to 4.08.

     
 