### PR TITLE
Duplicate the error message for "ocaml.error" nodes for version < 4.08

### DIFF
--- a/src/ast_402.ml
+++ b/src/ast_402.ml
@@ -2611,7 +2611,9 @@ end = struct
 
   let extension_of_error (error : Locations.location_error) : extension =
     Locations.extension_of_error
-      ~mk_pstr:(fun x -> PStr x)
+      ~mk_pstr:(function
+        | x :: l -> PStr (x :: x :: l)
+        | l -> PStr l)
       ~mk_extension:(fun x -> Str.extension x)
       ~mk_string_constant:(fun x -> Str.eval (Exp.constant (Asttypes.Const_string (x, None))))
       error

--- a/src/ast_403.ml
+++ b/src/ast_403.ml
@@ -2699,7 +2699,9 @@ end = struct
 
   let extension_of_error (error : Locations.location_error) : extension =
     Locations.extension_of_error
-      ~mk_pstr:(fun x -> PStr x)
+      ~mk_pstr:(function
+        | x :: l -> PStr (x :: x :: l)
+        | l -> PStr l)
       ~mk_extension:(fun x -> Str.extension x)
       ~mk_string_constant:(fun x -> Str.eval (Exp.constant (Pconst_string (x, None))))
       error

--- a/src/ast_404.ml
+++ b/src/ast_404.ml
@@ -2716,7 +2716,9 @@ end = struct
 
   let extension_of_error (error : Locations.location_error) : extension =
     Locations.extension_of_error
-      ~mk_pstr:(fun x -> PStr x)
+      ~mk_pstr:(function
+        | x :: l -> PStr (x :: x :: l)
+        | l -> PStr l)
       ~mk_extension:(fun x -> Str.extension x)
       ~mk_string_constant:(fun x -> Str.eval (Exp.constant (Pconst_string (x, None))))
       error

--- a/src/ast_405.ml
+++ b/src/ast_405.ml
@@ -2789,7 +2789,9 @@ end = struct
 
   let extension_of_error (error : Locations.location_error) : extension =
     Locations.extension_of_error
-      ~mk_pstr:(fun x -> PStr x)
+      ~mk_pstr:(function
+        | x :: l -> PStr (x :: x :: l)
+        | l -> PStr l)
       ~mk_extension:(fun x -> Str.extension x)
       ~mk_string_constant:(fun x -> Str.eval (Exp.constant (Pconst_string (x, None))))
       error

--- a/src/ast_406.ml
+++ b/src/ast_406.ml
@@ -2827,7 +2827,9 @@ end = struct
 
   let extension_of_error (error : Locations.location_error) : extension =
     Locations.extension_of_error
-      ~mk_pstr:(fun x -> PStr x)
+      ~mk_pstr:(function
+        | x :: l -> PStr (x :: x :: l)
+        | l -> PStr l)
       ~mk_extension:(fun x -> Str.extension x)
       ~mk_string_constant:(fun x -> Str.eval (Exp.constant (Pconst_string (x, None))))
       error

--- a/src/ast_407.ml
+++ b/src/ast_407.ml
@@ -2843,7 +2843,9 @@ end = struct
 
   let extension_of_error (error : Locations.location_error) : extension =
     Locations.extension_of_error
-      ~mk_pstr:(fun x -> PStr x)
+      ~mk_pstr:(function
+        | x :: l -> PStr (x :: x :: l)
+        | l -> PStr l)
       ~mk_extension:(fun x -> Str.extension x)
       ~mk_string_constant:(fun x -> Str.eval (Exp.constant (Pconst_string (x, None))))
       error


### PR DESCRIPTION
Bug reported and fixed by @hhugo.

The new function creating an "ocaml.error" should duplicate
its first element (as the message is kind of repeated: first is
the bare version and second is the highlighted version) for
all OCaml versions strictly before 4.08.