### PR TITLE
Infer file kind for binary ASTs

### DIFF
--- a/src/migrate_parsetree_driver.ml
+++ b/src/migrate_parsetree_driver.ml
@@ -314,9 +314,7 @@ let guess_file_kind fn =
   else if Filename.check_suffix fn ".mli" then
     Kind_intf
   else
-    Location.raise_errorf ~loc:(Location.in_file fn)
-      "I can't decide whether %s is an implementation or interface file"
-      fn
+    Kind_unknown
 
 let check_kind fn ~expected ~got =
   let describe = function
@@ -381,7 +379,9 @@ let load_file (kind, fn) =
       | Kind_intf ->
         (fn, Intf (Parse.interface lexbuf))
       | Kind_unknown ->
-        assert false)
+        Location.raise_errorf ~loc:(Location.in_file fn)
+          "I can't decide whether %s is an implementation or interface file"
+          fn)
 
 let with_output ?bin output ~f =
   match output with


### PR DESCRIPTION
Relaxes the driver command line parser so that if an input file is not specified with `--intf` or `--impl`, but as an anonymous argument, and turns out to be a binary AST, the file kind is loaded from the file contents. Previously, the parser tried to guess the file kind from the extension. The extension is ignored completely now.

This helps with BuckleScript integration, because current BuckleScript produces temporary binary AST files with no extension.