### PR TITLE
Add ?argv argument to Driver.run_main

### DIFF
--- a/src/migrate_parsetree_driver.ml
+++ b/src/migrate_parsetree_driver.ml
@@ -456,7 +456,7 @@ let print_transformations () =
   |> print_group "Registered Derivers"
 
 
-let run_as_standalone_driver () =
+let run_as_standalone_driver argv =
   let request_print_transformations = ref false in
   let output = ref None in
   let output_mode = ref Pretty_print in
@@ -520,7 +520,8 @@ let run_as_standalone_driver () =
   let usage = Printf.sprintf "%s [options] [<files>]" me in
   try
     reset_args ();
-    Arg.parse spec (fun anon -> files := guess_file_kind anon :: !files) usage;
+    Arg.parse_argv argv spec (fun anon ->
+      files := guess_file_kind anon :: !files) usage;
     if !request_print_transformations then begin
       print_transformations ();
       exit 0
@@ -544,8 +545,8 @@ let run_as_standalone_driver () =
     Location.report_exception Format.err_formatter exn;
     exit 1
 
-let run_as_ppx_rewriter () =
-  let a = Sys.argv in
+let run_as_ppx_rewriter ?(argv = Sys.argv) () =
+  let a = argv in
   let n = Array.length a in
   if n <= 2 then begin
     let me = Filename.basename Sys.executable_name in
@@ -565,9 +566,9 @@ let run_as_ppx_rewriter () =
       Location.report_exception Format.err_formatter exn;
       exit 1
 
-let run_main () =
-  if Array.length Sys.argv >= 2 && Sys.argv.(1) = "--as-ppx" then
-    run_as_ppx_rewriter ()
+let run_main ?(argv = Sys.argv) () =
+  if Array.length argv >= 2 && argv.(1) = "--as-ppx" then
+    run_as_ppx_rewriter ~argv ()
   else
-    run_as_standalone_driver ();
+    run_as_standalone_driver argv;
   exit 0

--- a/src/migrate_parsetree_driver.mli
+++ b/src/migrate_parsetree_driver.mli
@@ -75,9 +75,9 @@ val reset_args : unit -> unit
 
 val run_as_ast_mapper : string list -> Ast_mapper.mapper
 
-val run_as_ppx_rewriter : unit -> 'a
+val run_as_ppx_rewriter : ?argv:string array -> unit -> 'a
 
-val run_main : unit -> 'a
+val run_main : ?argv:string array -> unit -> 'a
 
 (** {1 Manual mapping} *)
 


### PR DESCRIPTION
The context is that Bisect_ppx needs to translate a command line issued by bsb into a different command line for the OMP driver (with Bisect_ppx linked in).

Until recently, Bisect_ppx `master` used a wrapper binary for this. The wrapper binary did the translation, found the Bisect_ppx OMP driver, and then called `exec`. This is fragile, because it depends on reconstructing paths. It is also annoying to maintain, if distributing precompiled binaries.

So, it seems better to link Bisect_ppx and OMP directly into the wrapper, and have the wrapper act as the final driver executable.