### PR TITLE
Allow not exiting on error, and parse command line from the first argument

### DIFF
--- a/src/migrate_parsetree_driver.ml
+++ b/src/migrate_parsetree_driver.ml
@@ -258,7 +258,7 @@ let rewrite_structure config version st =
   apply_cookies cookies;
   st
 
-let exit_or_raise exit_on_error f =
+let exit_or_raise ~exit_on_error f =
   if not exit_on_error then
     f ()
   else
@@ -284,7 +284,7 @@ let run_as_ast_mapper ?(exit_on_error = true) args =
      Printf.sprintf "%s [options] <input ast file> <output ast file>" me)
   in
   reset_args ();
-  exit_or_raise exit_on_error begin fun () ->
+  exit_or_raise ~exit_on_error begin fun () ->
     Arg.parse_argv ~current:(ref 0) args spec
       (fun arg -> raise (Arg.Bad (Printf.sprintf "invalid argument %S" arg)))
       usage;
@@ -492,7 +492,7 @@ let print_transformations () =
   |> print_group "Registered Derivers"
 
 
-let run_as_standalone_driver exit_on_error argv =
+let run_as_standalone_driver ~exit_on_error argv =
   let request_print_transformations = ref false in
   let output = ref None in
   let output_mode = ref Pretty_print in
@@ -554,7 +554,7 @@ let run_as_standalone_driver exit_on_error argv =
   let spec = Arg.align (spec @ registered_args ()) in
   let me = Filename.basename Sys.executable_name in
   let usage = Printf.sprintf "%s [options] [<files>]" me in
-  exit_or_raise exit_on_error begin fun () ->
+  exit_or_raise ~exit_on_error begin fun () ->
     reset_args ();
     Arg.parse_argv ~current:(ref 0) argv spec (fun anon ->
       files := (Kind_unknown, anon) :: !files) usage;
@@ -581,7 +581,7 @@ let run_as_standalone_driver exit_on_error argv =
 let run_as_ppx_rewriter ?(exit_on_error = true) ?(argv = Sys.argv) () =
   let a = argv in
   let n = Array.length a in
-  exit_or_raise exit_on_error begin fun () ->
+  exit_or_raise ~exit_on_error begin fun () ->
     if n <= 2 then begin
       let me = Filename.basename Sys.executable_name in
       Arg.usage_string (registered_args ())
@@ -596,4 +596,4 @@ let run_main ?(exit_on_error = true) ?(argv = Sys.argv) () =
   if Array.length argv >= 2 && argv.(1) = "--as-ppx" then
     run_as_ppx_rewriter ~exit_on_error ~argv ()
   else
-    run_as_standalone_driver exit_on_error argv
+    run_as_standalone_driver ~exit_on_error argv

--- a/src/migrate_parsetree_driver.ml
+++ b/src/migrate_parsetree_driver.ml
@@ -288,17 +288,17 @@ let run_as_ast_mapper ?(exit_on_error = true) args =
     Arg.parse_argv ~current:(ref 0) args spec
       (fun arg -> raise (Arg.Bad (Printf.sprintf "invalid argument %S" arg)))
       usage;
-      OCaml_current.Ast.make_top_mapper
-        ~signature:(fun sg ->
-            let config = initial_state () in
-            rewrite_signature config (module OCaml_current) sg
-            |> migrate_some_signature (module OCaml_current)
-          )
-        ~structure:(fun str ->
-            let config = initial_state () in
-            rewrite_structure config (module OCaml_current) str
-            |> migrate_some_structure (module OCaml_current)
-          )
+    OCaml_current.Ast.make_top_mapper
+      ~signature:(fun sg ->
+          let config = initial_state () in
+          rewrite_signature config (module OCaml_current) sg
+          |> migrate_some_signature (module OCaml_current)
+        )
+      ~structure:(fun str ->
+          let config = initial_state () in
+          rewrite_structure config (module OCaml_current) str
+          |> migrate_some_structure (module OCaml_current)
+        )
   end
 
 let protectx x ~finally ~f =
@@ -535,37 +535,36 @@ let run_as_standalone_driver exit_on_error argv =
     reset_args ();
     Arg.parse_argv ~current:(ref 0) argv spec (fun anon ->
       files := guess_file_kind anon :: !files) usage;
-    if !request_print_transformations then begin
-      print_transformations ();
-    end
+    if !request_print_transformations then
+      print_transformations ()
     else
-    let output = !output in
-    let output_mode = !output_mode in
-    let embed_errors = !embed_errors in
-    let config =
-      (* TODO: we could add -I, -L and -g options to populate these fields. *)
-      { tool_name    = "migrate_driver"
-      ; include_dirs = []
-      ; load_path    = []
-      ; debug        = false
-      ; for_package  = None
-      ; extras       = []
-      }
-    in
-    List.iter (process_file ~config ~output ~output_mode ~embed_errors)
-      (List.rev !files)
+      let output = !output in
+      let output_mode = !output_mode in
+      let embed_errors = !embed_errors in
+      let config =
+        (* TODO: we could add -I, -L and -g options to populate these fields. *)
+        { tool_name    = "migrate_driver"
+        ; include_dirs = []
+        ; load_path    = []
+        ; debug        = false
+        ; for_package  = None
+        ; extras       = []
+        }
+      in
+      List.iter (process_file ~config ~output ~output_mode ~embed_errors)
+        (List.rev !files)
   end
 
 let run_as_ppx_rewriter ?(exit_on_error = true) ?(argv = Sys.argv) () =
   let a = argv in
   let n = Array.length a in
   exit_or_raise exit_on_error begin fun () ->
-  if n <= 2 then begin
-    let me = Filename.basename Sys.executable_name in
-    Arg.usage_string (registered_args ())
-      (Printf.sprintf "%s [options] <input ast file> <output ast file>" me);
-    |> fun s -> raise (Arg.Bad s)
-  end;
+    if n <= 2 then begin
+      let me = Filename.basename Sys.executable_name in
+      Arg.usage_string (registered_args ())
+        (Printf.sprintf "%s [options] <input ast file> <output ast file>" me);
+      |> fun s -> raise (Arg.Bad s)
+    end;
     Ast_mapper.apply ~source:a.(n - 2) ~target:a.(n - 1)
       (run_as_ast_mapper (Array.to_list (Array.sub a 1 (n - 3))))
   end

--- a/src/migrate_parsetree_driver.mli
+++ b/src/migrate_parsetree_driver.mli
@@ -73,11 +73,12 @@ val reset_args : unit -> unit
 
 (** {1 Running registered rewriters} *)
 
-val run_as_ast_mapper : string list -> Ast_mapper.mapper
+val run_as_ast_mapper : ?exit_on_error:bool -> string list -> Ast_mapper.mapper
 
-val run_as_ppx_rewriter : ?argv:string array -> unit -> 'a
+val run_as_ppx_rewriter :
+  ?exit_on_error:bool -> ?argv:string array -> unit -> unit
 
-val run_main : ?argv:string array -> unit -> 'a
+val run_main : ?exit_on_error:bool -> ?argv:string array -> unit -> unit
 
 (** {1 Manual mapping} *)
 


### PR DESCRIPTION
Fixes #83.

- Passes `~current:(ref 0)` to [`Arg.parse_argv`](https://caml.inria.fr/pub/docs/manual-ocaml/libref/Arg.html#VALparse_argv), to ensure `~argv` is parsed from the beginning each time, in case OMP is linked into a larger process that calls into OMP multiple times.
- Adds `?exit_on_error` to functions that might parse arguments (i.e., act as top-level functions of the driver). The default value is `~exit_on_error:true`, which roughly mimics the behavior before this PR. If `~exit_on_error:false` is provided, none of the functions ever call `exit`. Instead, they raise (leak) the exceptions that would have terminated the process. I decided to add this to all functions because there are three top-level "entry points" into `Driver`, and they call each other, so they all need this change. It is modeled after [`Alcotest.run`](https://github.com/mirage/alcotest/blob/c224a830a3c50076b783314f904170fe79ee5c12/src/alcotest.mli#L56-L61).

This changes the result type of `Driver.run_main` and `Driver.run_as_ppx_rewriter` from `'a` to `unit`, because these functions no longer call `exit` in all paths unconditionally.

The `exit` behavior is also changed in a few other ways, even with `~exit_on_error:true`:

1. `run_main` no longer calls `exit 0` at its ends, so execution continues in the caller.
2. Exit codes are more disciplined. Previously, the exit code was sometimes 1 on `Arg.Help`, and 1 on `Arg.Bad`. In the former case, the help message would be printed to STDERR. Now, `Arg.Help` always prints to STDOUT, and the exit code is 0, and the exit code for `Arg.Bad` is always 2. This is in accordance with convention and [this code](https://github.com/ocaml/ocaml/blob/db7fee200fac08dfde1dd446bb2dce63c5a44140/stdlib/arg.ml#L287-L292) in `Arg`.
