### PR TITLE
Fix #97: version-specific magic numbers check in `Ast_4NN.register`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 
 - No longer expose the unwrapped modules
 
+- Fix version-specific magic numbers check in `Ast_4NN.register`
+  (#97, @gasche, @kit-ty-kate, @thierry-martinez)
+
 v1.7.3 2020-05-07 Canterbury
 ----------------------------
 

--- a/src/ast_408.ml
+++ b/src/ast_408.ml
@@ -2732,6 +2732,17 @@ end = struct
   end
 end
 
+module Config = struct
+  (** [in_ast_408] allows {!val:Ast_mapper.register} to compile correctly only
+      if this [Config] module has been overriden with the version-specific
+      magic numbers.
+      See {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97} *)
+  let in_ast_408 = ()
+
+  let ast_impl_magic_number = "Caml1999M025"
+  let ast_intf_magic_number = "Caml1999N025"
+end
+
 module Ast_mapper : sig
   open Parsetree
 
@@ -3821,6 +3832,7 @@ end = struct
     in
 
     let ic = open_in_bin source in
+    let () = Config.in_ast_408 in
     let magic =
       really_input_string ic (String.length Config.ast_impl_magic_number)
     in
@@ -4038,11 +4050,6 @@ module Outcometree = struct
     | Ophr_eval of out_value * out_type
     | Ophr_signature of (out_sig_item * out_value option) list
     | Ophr_exception of (exn * out_value)
-end
-
-module Config = struct
-  let ast_impl_magic_number = "Caml1999M025"
-  let ast_intf_magic_number = "Caml1999N025"
 end
 
 let map_signature mapper = mapper.Ast_mapper.signature mapper

--- a/src/ast_409.ml
+++ b/src/ast_409.ml
@@ -2721,6 +2721,17 @@ end = struct
   end
 end
 
+module Config = struct
+  (** [in_ast_409] allows {!val:Ast_mapper.register} to compile correctly only
+      if this [Config] module has been overriden with the version-specific
+      magic numbers.
+      See {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97} *)
+  let in_ast_409 = ()
+
+  let ast_impl_magic_number = "Caml1999M026"
+  let ast_intf_magic_number = "Caml1999N026"
+end
+
 module Ast_mapper : sig
   open Parsetree
 
@@ -3810,6 +3821,7 @@ end = struct
     in
 
     let ic = open_in_bin source in
+    let () = Config.in_ast_409 in
     let magic =
       really_input_string ic (String.length Config.ast_impl_magic_number)
     in
@@ -4027,11 +4039,6 @@ module Outcometree = struct
     | Ophr_eval of out_value * out_type
     | Ophr_signature of (out_sig_item * out_value option) list
     | Ophr_exception of (exn * out_value)
-end
-
-module Config = struct
-  let ast_impl_magic_number = "Caml1999M026"
-  let ast_intf_magic_number = "Caml1999N026"
 end
 
 let map_signature mapper = mapper.Ast_mapper.signature mapper

--- a/src/ast_410.ml
+++ b/src/ast_410.ml
@@ -2727,6 +2727,17 @@ end = struct
   end
 end
 
+module Config = struct
+  (** [in_ast_410] allows {!val:Ast_mapper.register} to compile correctly only
+      if this [Config] module has been overriden with the version-specific
+      magic numbers.
+      See {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97} *)
+  let in_ast_410 = ()
+
+  let ast_impl_magic_number = "Caml1999M027"
+  let ast_intf_magic_number = "Caml1999N027"
+end
+
 module Ast_mapper : sig
   open Parsetree
 
@@ -3824,6 +3835,7 @@ end = struct
     in
 
     let ic = open_in_bin source in
+    let () = Config.in_ast_410 in
     let magic =
       really_input_string ic (String.length Config.ast_impl_magic_number)
     in
@@ -4048,11 +4060,6 @@ module Outcometree = struct
     | Ophr_eval of out_value * out_type
     | Ophr_signature of (out_sig_item * out_value option) list
     | Ophr_exception of (exn * out_value)
-end
-
-module Config = struct
-  let ast_impl_magic_number = "Caml1999M027"
-  let ast_intf_magic_number = "Caml1999N027"
 end
 
 let map_signature mapper = mapper.Ast_mapper.signature mapper

--- a/src/ast_411.ml
+++ b/src/ast_411.ml
@@ -2728,6 +2728,17 @@ end = struct
   end
 end
 
+module Config = struct
+  (** [in_ast_411] allows {!val:Ast_mapper.register} to compile correctly only
+      if this [Config] module has been overriden with the version-specific
+      magic numbers.
+      See {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97} *)
+  let in_ast_411 = ()
+
+  let ast_impl_magic_number = "Caml1999M028"
+  let ast_intf_magic_number = "Caml1999N028"
+end
+
 module Ast_mapper : sig
   open Parsetree
 
@@ -3841,6 +3852,7 @@ end = struct
     in
 
     let ic = open_in_bin source in
+    let () = Config.in_ast_411 in
     let magic =
       really_input_string ic (String.length Config.ast_impl_magic_number)
     in
@@ -4065,11 +4077,6 @@ module Outcometree = struct
     | Ophr_eval of out_value * out_type
     | Ophr_signature of (out_sig_item * out_value option) list
     | Ophr_exception of (exn * out_value)
-end
-
-module Config = struct
-  let ast_impl_magic_number = "Caml1999M028"
-  let ast_intf_magic_number = "Caml1999N028"
 end
 
 let map_signature mapper = mapper.Ast_mapper.signature mapper


### PR DESCRIPTION
This commit fixes https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97, which caused segfaults: `Ast_4NN.register` now correctly checks AST magic number against the version-specific magic number instead of using the magic number defined in the `Config` module of the current compiler.

Version-specific magic numbers was already defined by overriding `Config` module later in the file: the fix just consists in riding up the overriding of `Config` before the overriding of `Ast_helper`. Following @gasche's trick recommended in https://github.com/ocaml-ppx/ppx_deriving/pull/210#issuecomment-632581603, a unit-value `in_ast_4nn` is defined in `Config` module and used in `Ast_helper.register` to ensure that the module are well ordered.