### PR TITLE
Another fix for #97: `Ast_4NN.register` reads and writes current AST

### DIFF
--- a/src/ast_408.ml
+++ b/src/ast_408.ml
@@ -2889,6 +2889,16 @@ module Ast_mapper : sig
 
   val set_cookie: string -> Parsetree.expression -> unit
   val get_cookie: string -> Parsetree.expression option
+
+  (** Reference to a converter from OCaml 4.08's mapper to mapper
+      for OCaml's current version.
+      This reference is filled in Migrate_parsetree once converters
+      are available.
+      This reference is used to implement {!val:register} such that
+      serialized AST are read and write with the OCaml's current types, to fix
+      {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97}}
+   *)
+  val to_current : (mapper -> Ast_mapper.mapper) ref
 end = struct
   open Parsetree
   open Ast_helper
@@ -3777,6 +3787,9 @@ end = struct
 
   let extension_of_exn exn = extension_of_error (Locations.location_error_of_exn exn)
 
+  let to_current : (mapper -> Ast_mapper.mapper) ref = ref (fun _ ->
+    failwith "Mapper converter not yet available")
+
   let apply_lazy ~source ~target mapper =
     let implem ast =
       let fields, ast =
@@ -3840,10 +3853,17 @@ end = struct
       failwith "Ast_mapper: OCaml version mismatch or malformed input";
     in
 
+    (* The following mapper fixes
+       {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97}*)
+    let mapper =
+      !to_current { default_mapper with
+         structure = (fun _ -> implem);
+         signature = (fun _ -> iface) } in
+
     if magic = Config.ast_impl_magic_number then
-      rewrite (implem : structure -> structure)
+      rewrite (mapper.structure mapper)
     else if magic = Config.ast_intf_magic_number then
-      rewrite (iface : signature -> signature)
+      rewrite (mapper.signature mapper)
     else fail ()
 
   let drop_ppx_context_str ~restore = function

--- a/src/ast_409.ml
+++ b/src/ast_409.ml
@@ -2878,6 +2878,16 @@ module Ast_mapper : sig
 
   val set_cookie: string -> Parsetree.expression -> unit
   val get_cookie: string -> Parsetree.expression option
+
+  (** Reference to a converter from OCaml 4.09's mapper to mapper
+      for OCaml's current version.
+      This reference is filled in Migrate_parsetree once converters
+      are available.
+      This reference is used to implement {!val:register} such that
+      serialized AST are read and write with the OCaml's current types, to fix
+      {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97}}
+   *)
+  val to_current : (mapper -> Ast_mapper.mapper) ref
 end = struct
   open Parsetree
   open Ast_helper
@@ -3766,6 +3776,9 @@ end = struct
 
   let extension_of_exn exn = extension_of_error (Locations.location_error_of_exn exn)
 
+  let to_current : (mapper -> Ast_mapper.mapper) ref = ref (fun _ ->
+    failwith "Mapper converter not yet available")
+
   let apply_lazy ~source ~target mapper =
     let implem ast =
       let fields, ast =
@@ -3829,10 +3842,17 @@ end = struct
       failwith "Ast_mapper: OCaml version mismatch or malformed input";
     in
 
+    (* The following mapper fixes
+       {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97}*)
+    let mapper =
+      !to_current { default_mapper with
+         structure = (fun _ -> implem);
+         signature = (fun _ -> iface) } in
+
     if magic = Config.ast_impl_magic_number then
-      rewrite (implem : structure -> structure)
+      rewrite (mapper.structure mapper)
     else if magic = Config.ast_intf_magic_number then
-      rewrite (iface : signature -> signature)
+      rewrite (mapper.signature mapper)
     else fail ()
 
   let drop_ppx_context_str ~restore = function

--- a/src/ast_411.ml
+++ b/src/ast_411.ml
@@ -2886,6 +2886,16 @@ module Ast_mapper : sig
 
   val set_cookie: string -> Parsetree.expression -> unit
   val get_cookie: string -> Parsetree.expression option
+
+  (** Reference to a converter from OCaml 4.11's mapper to mapper
+      for OCaml's current version.
+      This reference is filled in Migrate_parsetree once converters
+      are available.
+      This reference is used to implement {!val:register} such that
+      serialized AST are read and write with the OCaml's current types, to fix
+      {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97}}
+   *)
+  val to_current : (mapper -> Ast_mapper.mapper) ref
 end = struct
   open Parsetree
   open Ast_helper
@@ -3797,6 +3807,9 @@ end = struct
 
   let extension_of_exn exn = extension_of_error (Locations.location_error_of_exn exn)
 
+  let to_current : (mapper -> Ast_mapper.mapper) ref = ref (fun _ ->
+    failwith "Mapper converter not yet available")
+
   let apply_lazy ~source ~target mapper =
     let implem ast =
       let fields, ast =
@@ -3860,10 +3873,17 @@ end = struct
       failwith "Ast_mapper: OCaml version mismatch or malformed input";
     in
 
+    (* The following mapper fixes
+       {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97}*)
+    let mapper =
+      !to_current { default_mapper with
+         structure = (fun _ -> implem);
+         signature = (fun _ -> iface) } in
+
     if magic = Config.ast_impl_magic_number then
-      rewrite (implem : structure -> structure)
+      rewrite (mapper.structure mapper)
     else if magic = Config.ast_intf_magic_number then
-      rewrite (iface : signature -> signature)
+      rewrite (mapper.signature mapper)
     else fail ()
 
   let drop_ppx_context_str ~restore = function

--- a/src/migrate_parsetree.ml
+++ b/src/migrate_parsetree.ml
@@ -90,6 +90,29 @@ module OCaml_current = Versions.OCaml_current
    migrating from one to the other. *)
 module Convert = Versions.Convert
 
+module Ast_408_to_current = Convert (OCaml_408) (OCaml_current)
+
+(* Access to the convertion logic is given to version-specific Ast_mapper
+   to fix
+   {{:https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97}}. *)
+let () =
+  Ast_408.Ast_mapper.to_current := Ast_408_to_current.copy_mapper
+
+module Ast_409_to_current = Convert (OCaml_409) (OCaml_current)
+
+let () =
+  Ast_409.Ast_mapper.to_current := Ast_409_to_current.copy_mapper
+
+module Ast_410_to_current = Convert (OCaml_410) (OCaml_current)
+
+let () =
+  Ast_410.Ast_mapper.to_current := Ast_410_to_current.copy_mapper
+
+module Ast_411_to_current = Convert (OCaml_411) (OCaml_current)
+
+let () =
+  Ast_411.Ast_mapper.to_current := Ast_411_to_current.copy_mapper
+
 (* A [Parse] module that migrate ASTs to the desired version of an AST *)
 module Parse = Migrate_parsetree_parse
 


### PR DESCRIPTION
As @gasche explained in https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues/97#issuecomment-632660967, there is two possible semantics for `Ast_4NN.register`.

(1) register a 4NN-rewriter in such a way that it works on _current_ serialized ASTs

(2) register a 4NN-rewriter in such a way that it works on serialized ASTs for OCaml 4NN

This pull-request implements (1) whereas https://github.com/ocaml-ppx/ocaml-migrate-parsetree/pull/98 implements (2).