### PR TITLE
remove now-unsupported ppxlib driver

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -2,11 +2,7 @@
  (name migrate_parsetree)
  (public_name ocaml-migrate-parsetree)
  (libraries compiler-libs.common)
- (preprocess (action (run %{exe:../tools/pp.exe} %{read:ast-version} %{input-file})))
- (ppx.driver
-  (main       Migrate_parsetree.Driver.run_main)
-  (flags      --dump-ast)
-  (lint_flags --null)))
+ (preprocess (action (run %{exe:../tools/pp.exe} %{read:ast-version} %{input-file}))))
 
 (rule
  (targets ast-version)


### PR DESCRIPTION
The ppx.driver clause should have been removed when we removed its implementation.