### PR TITLE
Support 4.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,13 @@ over the diff to make sure the difference are relevant. The `ast_...`
 files require some adjustments which should pop up when you do this
 diff. Port the old adjustments to the new file as required.
 
-Add migration functions:
-- Manually compile the asts (`ocamlc -c src/ast_{NEW,OLD}.ml -I +compiler-libs -I _build/default/src/.migrate_parsetree.objs/byte/ -open Migrate_parsetree__`)
+Add migration functions. In the commands below, set $OLD and $NEW to the
+appropriate version numbers, e.g. 408 and 409:
+- Manually compile the asts (`ocamlc -c src/ast_{$NEW,$OLD}.ml -I +compiler-libs -I _build/default/src/.migrate_parsetree.objs/byte/`)
 - Using `tools/gencopy.exe` (`dune build tools/gencopy.exe`), generate copy code to and from previous version (assuming it is 408):
 ```
-_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_409:Ast_408 Ast_409.Parsetree.{expression,expr,pattern,pat,core_type,typ,toplevel_phrase} Ast_409.Outcometree.{out_phrase,out_type_extension} > src/migrate_parsetree_409_408_migrate.ml
-_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_408:Ast_409 Ast_408.Parsetree.{expression,expr,pattern,pat,core_type,typ,toplevel_phrase} Ast_408.Outcometree.{out_phrase,out_type_extension} > src/migrate_parsetree_408_409_migrate.ml
+_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$NEW:Ast_$OLD Ast_$NEW.Parsetree.{expression,expr,pattern,pat,core_type,typ,toplevel_phrase} Ast_$NEW.Outcometree.{out_phrase,out_type_extension} > src/migrate_parsetree_$NEW_$OLD_migrate.ml
+_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$OLD:Ast_$NEW Ast_$OLD.Parsetree.{expression,expr,pattern,pat,core_type,typ,toplevel_phrase} Ast_$OLD.Outcometree.{out_phrase,out_type_extension} > src/migrate_parsetree_$OLD_$NEW_migrate.ml
 ```
 - Fix the generated code by implementing new cases
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ appropriate version numbers, e.g. 408 and 409:
 - Manually compile the asts (`ocamlc -c src/ast_{$NEW,$OLD}.ml -I +compiler-libs -I _build/default/src/.migrate_parsetree.objs/byte/`)
 - Using `tools/gencopy.exe` (`dune build tools/gencopy.exe`), generate copy code to and from previous version (assuming it is 408):
 ```
-_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$NEW:Ast_$OLD Ast_$NEW.Parsetree.{expression,expr,pattern,pat,core_type,typ,toplevel_phrase} Ast_$NEW.Outcometree.{out_phrase,out_type_extension} > src/migrate_parsetree_$NEW_$OLD_migrate.ml
-_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$OLD:Ast_$NEW Ast_$OLD.Parsetree.{expression,expr,pattern,pat,core_type,typ,toplevel_phrase} Ast_$OLD.Outcometree.{out_phrase,out_type_extension} > src/migrate_parsetree_$OLD_$NEW_migrate.ml
+_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$NEW:Ast_$OLD Ast_$NEW.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${NEW}_${OLD}.ml
+_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$OLD:Ast_$NEW Ast_$OLD.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${OLD}_${NEW}.ml
 ```
 - Fix the generated code by implementing new cases
 

--- a/ocaml-migrate-parsetree.opam
+++ b/ocaml-migrate-parsetree.opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "dune" {>= "1.11"}
-  "ocaml" {>= "4.02.3" & < "4.12"}
+  "ocaml" {>= "4.02.3" & < "4.13"}
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """

--- a/src/ast_412.ml
+++ b/src/ast_412.ml
@@ -1,0 +1,1018 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                         OCaml Migrate Parsetree                        *)
+(*                                                                        *)
+(*                         Frédéric Bour, Facebook                        *)
+(*            Jérémie Dimino and Leo White, Jane Street Europe            *)
+(*            Xavier Leroy, projet Cristal, INRIA Rocquencourt            *)
+(*                         Alain Frisch, LexiFi                           *)
+(*       Daniel de Rauglaudre, projet Cristal, INRIA Rocquencourt         *)
+(*                                                                        *)
+(*   Copyright 2018 Institut National de Recherche en Informatique et     *)
+(*     en Automatique (INRIA).                                            *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+module Asttypes = struct
+  type constant (*IF_CURRENT = Asttypes.constant *) =
+      Const_int of int
+    | Const_char of char
+    | Const_string of string * Location.t * string option
+    | Const_float of string
+    | Const_int32 of int32
+    | Const_int64 of int64
+    | Const_nativeint of nativeint
+
+  type rec_flag (*IF_CURRENT = Asttypes.rec_flag *) = Nonrecursive | Recursive
+
+  type direction_flag (*IF_CURRENT = Asttypes.direction_flag *) = Upto | Downto
+
+  (* Order matters, used in polymorphic comparison *)
+  type private_flag (*IF_CURRENT = Asttypes.private_flag *) = Private | Public
+
+  type mutable_flag (*IF_CURRENT = Asttypes.mutable_flag *) = Immutable | Mutable
+
+  type virtual_flag (*IF_CURRENT = Asttypes.virtual_flag *) = Virtual | Concrete
+
+  type override_flag (*IF_CURRENT = Asttypes.override_flag *) = Override | Fresh
+
+  type closed_flag (*IF_CURRENT = Asttypes.closed_flag *) = Closed | Open
+
+  type label = string
+
+  type arg_label (*IF_CURRENT = Asttypes.arg_label *) =
+      Nolabel
+    | Labelled of string (*  label:T -> ... *)
+    | Optional of string (* ?label:T -> ... *)
+
+  type 'a loc = 'a Location.loc = {
+    txt : 'a;
+    loc : Location.t;
+  }
+
+
+  type variance (*IF_CURRENT = Asttypes.variance *) =
+    | Covariant
+    | Contravariant
+    | Invariant
+end
+
+module Parsetree = struct
+  open Asttypes
+
+  type constant (*IF_CURRENT = Parsetree.constant *) =
+      Pconst_integer of string * char option
+    (* 3 3l 3L 3n
+
+       Suffixes [g-z][G-Z] are accepted by the parser.
+       Suffixes except 'l', 'L' and 'n' are rejected by the typechecker
+    *)
+    | Pconst_char of char
+    (* 'c' *)
+    | Pconst_string of string * Location.t * string option
+    (* "constant"
+       {delim|other constant|delim}
+
+       The location span the content of the string, without the delimiters.
+    *)
+    | Pconst_float of string * char option
+    (* 3.4 2e5 1.4e-4
+
+       Suffixes [g-z][G-Z] are accepted by the parser.
+       Suffixes are rejected by the typechecker.
+    *)
+
+  type location_stack = Location.t list
+
+  (** {1 Extension points} *)
+
+  type attribute (*IF_CURRENT = Parsetree.attribute *) = {
+    attr_name : string loc;
+    attr_payload : payload;
+    attr_loc : Location.t;
+  }
+  (* [@id ARG]
+     [@@id ARG]
+
+     Metadata containers passed around within the AST.
+     The compiler ignores unknown attributes.
+  *)
+
+  and extension = string loc * payload
+  (* [%id ARG]
+     [%%id ARG]
+
+     Sub-language placeholder -- rejected by the typechecker.
+  *)
+
+  and attributes = attribute list
+
+  and payload (*IF_CURRENT = Parsetree.payload *) =
+    | PStr of structure
+    | PSig of signature (* : SIG *)
+    | PTyp of core_type  (* : T *)
+    | PPat of pattern * expression option  (* ? P  or  ? P when E *)
+
+  (** {1 Core language} *)
+
+  (* Type expressions *)
+
+  and core_type (*IF_CURRENT = Parsetree.core_type *) =
+    {
+      ptyp_desc: core_type_desc;
+      ptyp_loc: Location.t;
+      ptyp_loc_stack: location_stack;
+      ptyp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+  and core_type_desc (*IF_CURRENT = Parsetree.core_type_desc *) =
+    | Ptyp_any
+    (*  _ *)
+    | Ptyp_var of string
+    (* 'a *)
+    | Ptyp_arrow of arg_label * core_type * core_type
+    (* T1 -> T2       Simple
+       ~l:T1 -> T2    Labelled
+       ?l:T1 -> T2    Optional
+    *)
+    | Ptyp_tuple of core_type list
+    (* T1 * ... * Tn
+
+       Invariant: n >= 2
+    *)
+    | Ptyp_constr of Longident.t loc * core_type list
+    (* tconstr
+       T tconstr
+       (T1, ..., Tn) tconstr
+    *)
+    | Ptyp_object of object_field list * closed_flag
+    (* < l1:T1; ...; ln:Tn >     (flag = Closed)
+       < l1:T1; ...; ln:Tn; .. > (flag = Open)
+    *)
+    | Ptyp_class of Longident.t loc * core_type list
+    (* #tconstr
+       T #tconstr
+       (T1, ..., Tn) #tconstr
+    *)
+    | Ptyp_alias of core_type * string
+    (* T as 'a *)
+    | Ptyp_variant of row_field list * closed_flag * label list option
+    (* [ `A|`B ]         (flag = Closed; labels = None)
+       [> `A|`B ]        (flag = Open;   labels = None)
+       [< `A|`B ]        (flag = Closed; labels = Some [])
+       [< `A|`B > `X `Y ](flag = Closed; labels = Some ["X";"Y"])
+    *)
+    | Ptyp_poly of string loc list * core_type
+    (* 'a1 ... 'an. T
+
+       Can only appear in the following context:
+
+       - As the core_type of a Ppat_constraint node corresponding
+         to a constraint on a let-binding: let x : 'a1 ... 'an. T
+         = e ...
+
+       - Under Cfk_virtual for methods (not values).
+
+       - As the core_type of a Pctf_method node.
+
+       - As the core_type of a Pexp_poly node.
+
+       - As the pld_type field of a label_declaration.
+
+       - As a core_type of a Ptyp_object node.
+    *)
+
+    | Ptyp_package of package_type
+    (* (module S) *)
+    | Ptyp_extension of extension
+    (* [%id] *)
+
+  and package_type = Longident.t loc * (Longident.t loc * core_type) list
+      (*
+        (module S)
+        (module S with type t1 = T1 and ... and tn = Tn)
+       *)
+
+  and row_field (*IF_CURRENT = Parsetree.row_field *) = {
+    prf_desc : row_field_desc;
+    prf_loc : Location.t;
+    prf_attributes : attributes;
+  }
+
+  and row_field_desc (*IF_CURRENT = Parsetree.row_field_desc *) =
+    | Rtag of label loc * bool * core_type list
+    (* [`A]                   ( true,  [] )
+       [`A of T]              ( false, [T] )
+       [`A of T1 & .. & Tn]   ( false, [T1;...Tn] )
+       [`A of & T1 & .. & Tn] ( true,  [T1;...Tn] )
+
+       - The 'bool' field is true if the tag contains a
+         constant (empty) constructor.
+       - '&' occurs when several types are used for the same constructor
+         (see 4.2 in the manual)
+    *)
+    | Rinherit of core_type
+    (* [ T ] *)
+
+  and object_field (*IF_CURRENT = Parsetree.object_field *) = {
+    pof_desc : object_field_desc;
+    pof_loc : Location.t;
+    pof_attributes : attributes;
+  }
+
+  and object_field_desc (*IF_CURRENT = Parsetree.object_field_desc *) =
+    | Otag of label loc * core_type
+    | Oinherit of core_type
+
+  (* Patterns *)
+
+  and pattern (*IF_CURRENT = Parsetree.pattern *) =
+    {
+      ppat_desc: pattern_desc;
+      ppat_loc: Location.t;
+      ppat_loc_stack: location_stack;
+      ppat_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+  and pattern_desc (*IF_CURRENT = Parsetree.pattern_desc *) =
+    | Ppat_any
+    (* _ *)
+    | Ppat_var of string loc
+    (* x *)
+    | Ppat_alias of pattern * string loc
+    (* P as 'a *)
+    | Ppat_constant of constant
+    (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+    | Ppat_interval of constant * constant
+    (* 'a'..'z'
+
+       Other forms of interval are recognized by the parser
+       but rejected by the type-checker. *)
+    | Ppat_tuple of pattern list
+    (* (P1, ..., Pn)
+
+       Invariant: n >= 2
+    *)
+    | Ppat_construct of Longident.t loc * pattern option
+    (* C                None
+       C P              Some P
+       C (P1, ..., Pn)  Some (Ppat_tuple [P1; ...; Pn])
+    *)
+    | Ppat_variant of label * pattern option
+    (* `A             (None)
+       `A P           (Some P)
+    *)
+    | Ppat_record of (Longident.t loc * pattern) list * closed_flag
+    (* { l1=P1; ...; ln=Pn }     (flag = Closed)
+       { l1=P1; ...; ln=Pn; _}   (flag = Open)
+
+       Invariant: n > 0
+    *)
+    | Ppat_array of pattern list
+    (* [| P1; ...; Pn |] *)
+    | Ppat_or of pattern * pattern
+    (* P1 | P2 *)
+    | Ppat_constraint of pattern * core_type
+    (* (P : T) *)
+    | Ppat_type of Longident.t loc
+    (* #tconst *)
+    | Ppat_lazy of pattern
+    (* lazy P *)
+    | Ppat_unpack of string option loc
+    (* (module P)        Some "P"
+       (module _)        None
+
+       Note: (module P : S) is represented as
+       Ppat_constraint(Ppat_unpack, Ptyp_package)
+    *)
+    | Ppat_exception of pattern
+    (* exception P *)
+    | Ppat_extension of extension
+    (* [%id] *)
+    | Ppat_open of Longident.t loc * pattern
+    (* M.(P) *)
+
+  (* Value expressions *)
+
+  and expression (*IF_CURRENT = Parsetree.expression *) =
+    {
+      pexp_desc: expression_desc;
+      pexp_loc: Location.t;
+      pexp_loc_stack: location_stack;
+      pexp_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+  and expression_desc (*IF_CURRENT = Parsetree.expression_desc *) =
+    | Pexp_ident of Longident.t loc
+    (* x
+       M.x
+    *)
+    | Pexp_constant of constant
+    (* 1, 'a', "true", 1.0, 1l, 1L, 1n *)
+    | Pexp_let of rec_flag * value_binding list * expression
+    (* let P1 = E1 and ... and Pn = EN in E       (flag = Nonrecursive)
+       let rec P1 = E1 and ... and Pn = EN in E   (flag = Recursive)
+    *)
+    | Pexp_function of case list
+    (* function P1 -> E1 | ... | Pn -> En *)
+    | Pexp_fun of arg_label * expression option * pattern * expression
+    (* fun P -> E1                          (Simple, None)
+       fun ~l:P -> E1                       (Labelled l, None)
+       fun ?l:P -> E1                       (Optional l, None)
+       fun ?l:(P = E0) -> E1                (Optional l, Some E0)
+
+       Notes:
+       - If E0 is provided, only Optional is allowed.
+       - "fun P1 P2 .. Pn -> E1" is represented as nested Pexp_fun.
+       - "let f P = E" is represented using Pexp_fun.
+    *)
+    | Pexp_apply of expression * (arg_label * expression) list
+    (* E0 ~l1:E1 ... ~ln:En
+       li can be empty (non labeled argument) or start with '?'
+       (optional argument).
+
+       Invariant: n > 0
+    *)
+    | Pexp_match of expression * case list
+    (* match E0 with P1 -> E1 | ... | Pn -> En *)
+    | Pexp_try of expression * case list
+    (* try E0 with P1 -> E1 | ... | Pn -> En *)
+    | Pexp_tuple of expression list
+    (* (E1, ..., En)
+
+       Invariant: n >= 2
+    *)
+    | Pexp_construct of Longident.t loc * expression option
+    (* C                None
+       C E              Some E
+       C (E1, ..., En)  Some (Pexp_tuple[E1;...;En])
+    *)
+    | Pexp_variant of label * expression option
+    (* `A             (None)
+       `A E           (Some E)
+    *)
+    | Pexp_record of (Longident.t loc * expression) list * expression option
+    (* { l1=P1; ...; ln=Pn }     (None)
+       { E0 with l1=P1; ...; ln=Pn }   (Some E0)
+
+       Invariant: n > 0
+    *)
+    | Pexp_field of expression * Longident.t loc
+    (* E.l *)
+    | Pexp_setfield of expression * Longident.t loc * expression
+    (* E1.l <- E2 *)
+    | Pexp_array of expression list
+    (* [| E1; ...; En |] *)
+    | Pexp_ifthenelse of expression * expression * expression option
+    (* if E1 then E2 else E3 *)
+    | Pexp_sequence of expression * expression
+    (* E1; E2 *)
+    | Pexp_while of expression * expression
+    (* while E1 do E2 done *)
+    | Pexp_for of
+        pattern *  expression * expression * direction_flag * expression
+    (* for i = E1 to E2 do E3 done      (flag = Upto)
+       for i = E1 downto E2 do E3 done  (flag = Downto)
+    *)
+    | Pexp_constraint of expression * core_type
+    (* (E : T) *)
+    | Pexp_coerce of expression * core_type option * core_type
+    (* (E :> T)        (None, T)
+       (E : T0 :> T)   (Some T0, T)
+    *)
+    | Pexp_send of expression * label loc
+    (*  E # m *)
+    | Pexp_new of Longident.t loc
+    (* new M.c *)
+    | Pexp_setinstvar of label loc * expression
+    (* x <- 2 *)
+    | Pexp_override of (label loc * expression) list
+    (* {< x1 = E1; ...; Xn = En >} *)
+    | Pexp_letmodule of string option loc * module_expr * expression
+    (* let module M = ME in E *)
+    | Pexp_letexception of extension_constructor * expression
+    (* let exception C in E *)
+    | Pexp_assert of expression
+    (* assert E
+       Note: "assert false" is treated in a special way by the
+       type-checker. *)
+    | Pexp_lazy of expression
+    (* lazy E *)
+    | Pexp_poly of expression * core_type option
+    (* Used for method bodies.
+
+       Can only be used as the expression under Cfk_concrete
+       for methods (not values). *)
+    | Pexp_object of class_structure
+    (* object ... end *)
+    | Pexp_newtype of string loc * expression
+    (* fun (type t) -> E *)
+    | Pexp_pack of module_expr
+    (* (module ME)
+
+       (module ME : S) is represented as
+       Pexp_constraint(Pexp_pack, Ptyp_package S) *)
+    | Pexp_open of open_declaration * expression
+    (* M.(E)
+       let open M in E
+       let! open M in E *)
+    | Pexp_letop of letop
+    (* let* P = E in E
+       let* P = E and* P = E in E *)
+    | Pexp_extension of extension
+    (* [%id] *)
+    | Pexp_unreachable
+    (* . *)
+
+  and case (*IF_CURRENT = Parsetree.case *) =   (* (P -> E) or (P when E0 -> E) *)
+    {
+      pc_lhs: pattern;
+      pc_guard: expression option;
+      pc_rhs: expression;
+    }
+
+  and letop (*IF_CURRENT = Parsetree.letop *) =
+    {
+      let_ : binding_op;
+      ands : binding_op list;
+      body : expression;
+    }
+
+  and binding_op (*IF_CURRENT = Parsetree.binding_op *) =
+    {
+      pbop_op : string loc;
+      pbop_pat : pattern;
+      pbop_exp : expression;
+      pbop_loc : Location.t;
+    }
+
+  (* Value descriptions *)
+
+  and value_description (*IF_CURRENT = Parsetree.value_description *) =
+    {
+      pval_name: string loc;
+      pval_type: core_type;
+      pval_prim: string list;
+      pval_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+      pval_loc: Location.t;
+    }
+
+(*
+  val x: T                            (prim = [])
+  external x: T = "s1" ... "sn"       (prim = ["s1";..."sn"])
+*)
+
+  (* Type declarations *)
+
+  and type_declaration (*IF_CURRENT = Parsetree.type_declaration *) =
+    {
+      ptype_name: string loc;
+      ptype_params: (core_type * variance) list;
+      (* ('a1,...'an) t; None represents  _*)
+      ptype_cstrs: (core_type * core_type * Location.t) list;
+      (* ... constraint T1=T1'  ... constraint Tn=Tn' *)
+      ptype_kind: type_kind;
+      ptype_private: private_flag;   (* = private ... *)
+      ptype_manifest: core_type option;  (* = T *)
+      ptype_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+      ptype_loc: Location.t;
+    }
+
+(*
+  type t                     (abstract, no manifest)
+  type t = T0                (abstract, manifest=T0)
+  type t = C of T | ...      (variant,  no manifest)
+  type t = T0 = C of T | ... (variant,  manifest=T0)
+  type t = {l: T; ...}       (record,   no manifest)
+  type t = T0 = {l : T; ...} (record,   manifest=T0)
+  type t = ..                (open,     no manifest)
+*)
+
+  and type_kind (*IF_CURRENT = Parsetree.type_kind *) =
+    | Ptype_abstract
+    | Ptype_variant of constructor_declaration list
+    | Ptype_record of label_declaration list
+    (* Invariant: non-empty list *)
+    | Ptype_open
+
+  and label_declaration (*IF_CURRENT = Parsetree.label_declaration *) =
+    {
+      pld_name: string loc;
+      pld_mutable: mutable_flag;
+      pld_type: core_type;
+      pld_loc: Location.t;
+      pld_attributes: attributes; (* l : T [@id1] [@id2] *)
+    }
+
+  (*  { ...; l: T; ... }            (mutable=Immutable)
+      { ...; mutable l: T; ... }    (mutable=Mutable)
+
+      Note: T can be a Ptyp_poly.
+  *)
+
+  and constructor_declaration (*IF_CURRENT = Parsetree.constructor_declaration *) =
+    {
+      pcd_name: string loc;
+      pcd_args: constructor_arguments;
+      pcd_res: core_type option;
+      pcd_loc: Location.t;
+      pcd_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+  and constructor_arguments (*IF_CURRENT = Parsetree.constructor_arguments *) =
+    | Pcstr_tuple of core_type list
+    | Pcstr_record of label_declaration list
+
+(*
+  | C of T1 * ... * Tn     (res = None,    args = Pcstr_tuple [])
+  | C: T0                  (res = Some T0, args = [])
+  | C: T1 * ... * Tn -> T0 (res = Some T0, args = Pcstr_tuple)
+  | C of {...}             (res = None,    args = Pcstr_record)
+  | C: {...} -> T0         (res = Some T0, args = Pcstr_record)
+  | C of {...} as t        (res = None,    args = Pcstr_record)
+*)
+
+  and type_extension (*IF_CURRENT = Parsetree.type_extension *) =
+    {
+      ptyext_path: Longident.t loc;
+      ptyext_params: (core_type * variance) list;
+      ptyext_constructors: extension_constructor list;
+      ptyext_private: private_flag;
+      ptyext_loc: Location.t;
+      ptyext_attributes: attributes;   (* ... [@@id1] [@@id2] *)
+    }
+(*
+  type t += ...
+*)
+
+  and extension_constructor (*IF_CURRENT = Parsetree.extension_constructor *) =
+    {
+      pext_name: string loc;
+      pext_kind : extension_constructor_kind;
+      pext_loc : Location.t;
+      pext_attributes: attributes; (* C of ... [@id1] [@id2] *)
+    }
+
+  (* exception E *)
+  and type_exception (*IF_CURRENT = Parsetree.type_exception *) =
+    {
+      ptyexn_constructor: extension_constructor;
+      ptyexn_loc: Location.t;
+      ptyexn_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+  and extension_constructor_kind (*IF_CURRENT = Parsetree.extension_constructor_kind *) =
+      Pext_decl of constructor_arguments * core_type option
+      (*
+         | C of T1 * ... * Tn     ([T1; ...; Tn], None)
+         | C: T0                  ([], Some T0)
+         | C: T1 * ... * Tn -> T0 ([T1; ...; Tn], Some T0)
+       *)
+    | Pext_rebind of Longident.t loc
+      (*
+         | C = D
+       *)
+
+  (** {1 Class language} *)
+
+  (* Type expressions for the class language *)
+
+  and class_type (*IF_CURRENT = Parsetree.class_type *) =
+    {
+      pcty_desc: class_type_desc;
+      pcty_loc: Location.t;
+      pcty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+  and class_type_desc (*IF_CURRENT = Parsetree.class_type_desc *) =
+    | Pcty_constr of Longident.t loc * core_type list
+    (* c
+       ['a1, ..., 'an] c *)
+    | Pcty_signature of class_signature
+    (* object ... end *)
+    | Pcty_arrow of arg_label * core_type * class_type
+    (* T -> CT       Simple
+       ~l:T -> CT    Labelled l
+       ?l:T -> CT    Optional l
+    *)
+    | Pcty_extension of extension
+    (* [%id] *)
+    | Pcty_open of open_description * class_type
+    (* let open M in CT *)
+
+  and class_signature (*IF_CURRENT = Parsetree.class_signature *) =
+    {
+      pcsig_self: core_type;
+      pcsig_fields: class_type_field list;
+    }
+  (* object('selfpat) ... end
+     object ... end             (self = Ptyp_any)
+  *)
+
+  and class_type_field (*IF_CURRENT = Parsetree.class_type_field *) =
+    {
+      pctf_desc: class_type_field_desc;
+      pctf_loc: Location.t;
+      pctf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+  and class_type_field_desc (*IF_CURRENT = Parsetree.class_type_field_desc *) =
+    | Pctf_inherit of class_type
+    (* inherit CT *)
+    | Pctf_val of (label loc * mutable_flag * virtual_flag * core_type)
+    (* val x: T *)
+    | Pctf_method  of (label loc * private_flag * virtual_flag * core_type)
+    (* method x: T
+
+       Note: T can be a Ptyp_poly.
+    *)
+    | Pctf_constraint  of (core_type * core_type)
+    (* constraint T1 = T2 *)
+    | Pctf_attribute of attribute
+    (* [@@@id] *)
+    | Pctf_extension of extension
+    (* [%%id] *)
+
+  and 'a class_infos (*IF_CURRENT = 'a Parsetree.class_infos *) =
+    {
+      pci_virt: virtual_flag;
+      pci_params: (core_type * variance) list;
+      pci_name: string loc;
+      pci_expr: 'a;
+      pci_loc: Location.t;
+      pci_attributes: attributes;  (* ... [@@id1] [@@id2] *)
+    }
+  (* class c = ...
+     class ['a1,...,'an] c = ...
+     class virtual c = ...
+
+     Also used for "class type" declaration.
+  *)
+
+  and class_description = class_type class_infos
+
+  and class_type_declaration = class_type class_infos
+
+  (* Value expressions for the class language *)
+
+  and class_expr (*IF_CURRENT = Parsetree.class_expr *) =
+    {
+      pcl_desc: class_expr_desc;
+      pcl_loc: Location.t;
+      pcl_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+  and class_expr_desc (*IF_CURRENT = Parsetree.class_expr_desc *) =
+    | Pcl_constr of Longident.t loc * core_type list
+    (* c
+       ['a1, ..., 'an] c *)
+    | Pcl_structure of class_structure
+    (* object ... end *)
+    | Pcl_fun of arg_label * expression option * pattern * class_expr
+    (* fun P -> CE                          (Simple, None)
+       fun ~l:P -> CE                       (Labelled l, None)
+       fun ?l:P -> CE                       (Optional l, None)
+       fun ?l:(P = E0) -> CE                (Optional l, Some E0)
+    *)
+    | Pcl_apply of class_expr * (arg_label * expression) list
+    (* CE ~l1:E1 ... ~ln:En
+       li can be empty (non labeled argument) or start with '?'
+       (optional argument).
+
+       Invariant: n > 0
+    *)
+    | Pcl_let of rec_flag * value_binding list * class_expr
+    (* let P1 = E1 and ... and Pn = EN in CE      (flag = Nonrecursive)
+       let rec P1 = E1 and ... and Pn = EN in CE  (flag = Recursive)
+    *)
+    | Pcl_constraint of class_expr * class_type
+    (* (CE : CT) *)
+    | Pcl_extension of extension
+    (* [%id] *)
+    | Pcl_open of open_description * class_expr
+    (* let open M in CE *)
+
+
+  and class_structure (*IF_CURRENT = Parsetree.class_structure *) =
+    {
+      pcstr_self: pattern;
+      pcstr_fields: class_field list;
+    }
+  (* object(selfpat) ... end
+     object ... end           (self = Ppat_any)
+  *)
+
+  and class_field (*IF_CURRENT = Parsetree.class_field *) =
+    {
+      pcf_desc: class_field_desc;
+      pcf_loc: Location.t;
+      pcf_attributes: attributes; (* ... [@@id1] [@@id2] *)
+    }
+
+  and class_field_desc (*IF_CURRENT = Parsetree.class_field_desc *) =
+    | Pcf_inherit of override_flag * class_expr * string loc option
+    (* inherit CE
+       inherit CE as x
+       inherit! CE
+       inherit! CE as x
+    *)
+    | Pcf_val of (label loc * mutable_flag * class_field_kind)
+    (* val x = E
+       val virtual x: T
+    *)
+    | Pcf_method of (label loc * private_flag * class_field_kind)
+    (* method x = E            (E can be a Pexp_poly)
+       method virtual x: T     (T can be a Ptyp_poly)
+    *)
+    | Pcf_constraint of (core_type * core_type)
+    (* constraint T1 = T2 *)
+    | Pcf_initializer of expression
+    (* initializer E *)
+    | Pcf_attribute of attribute
+    (* [@@@id] *)
+    | Pcf_extension of extension
+    (* [%%id] *)
+
+  and class_field_kind (*IF_CURRENT = Parsetree.class_field_kind *) =
+    | Cfk_virtual of core_type
+    | Cfk_concrete of override_flag * expression
+
+  and class_declaration = class_expr class_infos
+
+  (** {1 Module language} *)
+
+  (* Type expressions for the module language *)
+
+  and module_type (*IF_CURRENT = Parsetree.module_type *) =
+    {
+      pmty_desc: module_type_desc;
+      pmty_loc: Location.t;
+      pmty_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+  and module_type_desc (*IF_CURRENT = Parsetree.module_type_desc *) =
+    | Pmty_ident of Longident.t loc
+    (* S *)
+    | Pmty_signature of signature
+    (* sig ... end *)
+    | Pmty_functor of functor_parameter * module_type
+    (* functor(X : MT1) -> MT2 *)
+    | Pmty_with of module_type * with_constraint list
+    (* MT with ... *)
+    | Pmty_typeof of module_expr
+    (* module type of ME *)
+    | Pmty_extension of extension
+    (* [%id] *)
+    | Pmty_alias of Longident.t loc
+    (* (module M) *)
+
+  and functor_parameter (*IF_CURRENT = Parsetree.functor_parameter *) =
+    | Unit
+    (* () *)
+    | Named of string option loc * module_type
+    (* (X : MT)          Some X, MT
+       (_ : MT)          None, MT *)
+
+  and signature = signature_item list
+
+  and signature_item (*IF_CURRENT = Parsetree.signature_item *) =
+    {
+      psig_desc: signature_item_desc;
+      psig_loc: Location.t;
+    }
+
+  and signature_item_desc (*IF_CURRENT = Parsetree.signature_item_desc *) =
+    | Psig_value of value_description
+        (*
+          val x: T
+          external x: T = "s1" ... "sn"
+         *)
+    | Psig_type of rec_flag * type_declaration list
+    (* type t1 = ... and ... and tn  = ... *)
+    | Psig_typesubst of type_declaration list
+    (* type t1 := ... and ... and tn := ...  *)
+    | Psig_typext of type_extension
+    (* type t1 += ... *)
+    | Psig_exception of type_exception
+    (* exception C of T *)
+    | Psig_module of module_declaration
+    (* module X = M
+       module X : MT *)
+    | Psig_modsubst of module_substitution
+    (* module X := M *)
+    | Psig_recmodule of module_declaration list
+    (* module rec X1 : MT1 and ... and Xn : MTn *)
+    | Psig_modtype of module_type_declaration
+    (* module type S = MT
+       module type S *)
+    | Psig_open of open_description
+    (* open X *)
+    | Psig_include of include_description
+    (* include MT *)
+    | Psig_class of class_description list
+    (* class c1 : ... and ... and cn : ... *)
+    | Psig_class_type of class_type_declaration list
+    (* class type ct1 = ... and ... and ctn = ... *)
+    | Psig_attribute of attribute
+    (* [@@@id] *)
+    | Psig_extension of extension * attributes
+    (* [%%id] *)
+
+  and module_declaration (*IF_CURRENT = Parsetree.module_declaration *) =
+    {
+      pmd_name: string option loc;
+      pmd_type: module_type;
+      pmd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+      pmd_loc: Location.t;
+    }
+  (* S : MT *)
+
+  and module_substitution (*IF_CURRENT = Parsetree.module_substitution *) =
+    {
+      pms_name: string loc;
+      pms_manifest: Longident.t loc;
+      pms_attributes: attributes; (* ... [@@id1] [@@id2] *)
+      pms_loc: Location.t;
+    }
+
+  and module_type_declaration (*IF_CURRENT = Parsetree.module_type_declaration *) =
+    {
+      pmtd_name: string loc;
+      pmtd_type: module_type option;
+      pmtd_attributes: attributes; (* ... [@@id1] [@@id2] *)
+      pmtd_loc: Location.t;
+    }
+  (* S = MT
+     S       (abstract module type declaration, pmtd_type = None)
+  *)
+
+  and 'a open_infos (*IF_CURRENT = 'a Parsetree.open_infos *) =
+    {
+      popen_expr: 'a;
+      popen_override: override_flag;
+      popen_loc: Location.t;
+      popen_attributes: attributes;
+    }
+  (* open! X - popen_override = Override (silences the 'used identifier
+                                shadowing' warning)
+     open  X - popen_override = Fresh
+  *)
+
+  and open_description = Longident.t loc open_infos
+  (* open M.N
+     open M(N).O *)
+
+  and open_declaration = module_expr open_infos
+  (* open M.N
+     open M(N).O
+     open struct ... end *)
+
+  and 'a include_infos (*IF_CURRENT = 'a Parsetree.include_infos *) =
+    {
+      pincl_mod: 'a;
+      pincl_loc: Location.t;
+      pincl_attributes: attributes;
+    }
+
+  and include_description = module_type include_infos
+  (* include MT *)
+
+  and include_declaration = module_expr include_infos
+  (* include ME *)
+
+  and with_constraint (*IF_CURRENT = Parsetree.with_constraint *) =
+    | Pwith_type of Longident.t loc * type_declaration
+    (* with type X.t = ...
+
+       Note: the last component of the longident must match
+       the name of the type_declaration. *)
+    | Pwith_module of Longident.t loc * Longident.t loc
+    (* with module X.Y = Z *)
+    | Pwith_typesubst of Longident.t loc * type_declaration
+    (* with type X.t := ..., same format as [Pwith_type] *)
+    | Pwith_modsubst of Longident.t loc * Longident.t loc
+    (* with module X.Y := Z *)
+
+  (* Value expressions for the module language *)
+
+  and module_expr (*IF_CURRENT = Parsetree.module_expr *) =
+    {
+      pmod_desc: module_expr_desc;
+      pmod_loc: Location.t;
+      pmod_attributes: attributes; (* ... [@id1] [@id2] *)
+    }
+
+  and module_expr_desc (*IF_CURRENT = Parsetree.module_expr_desc *) =
+    | Pmod_ident of Longident.t loc
+    (* X *)
+    | Pmod_structure of structure
+    (* struct ... end *)
+    | Pmod_functor of functor_parameter * module_expr
+    (* functor(X : MT1) -> ME *)
+    | Pmod_apply of module_expr * module_expr
+    (* ME1(ME2) *)
+    | Pmod_constraint of module_expr * module_type
+    (* (ME : MT) *)
+    | Pmod_unpack of expression
+    (* (val E) *)
+    | Pmod_extension of extension
+    (* [%id] *)
+
+  and structure = structure_item list
+
+  and structure_item (*IF_CURRENT = Parsetree.structure_item *) =
+    {
+      pstr_desc: structure_item_desc;
+      pstr_loc: Location.t;
+    }
+
+  and structure_item_desc (*IF_CURRENT = Parsetree.structure_item_desc *) =
+    | Pstr_eval of expression * attributes
+    (* E *)
+    | Pstr_value of rec_flag * value_binding list
+    (* let P1 = E1 and ... and Pn = EN       (flag = Nonrecursive)
+       let rec P1 = E1 and ... and Pn = EN   (flag = Recursive)
+    *)
+    | Pstr_primitive of value_description
+    (*  val x: T
+        external x: T = "s1" ... "sn" *)
+    | Pstr_type of rec_flag * type_declaration list
+    (* type t1 = ... and ... and tn = ... *)
+    | Pstr_typext of type_extension
+    (* type t1 += ... *)
+    | Pstr_exception of type_exception
+    (* exception C of T
+       exception C = M.X *)
+    | Pstr_module of module_binding
+    (* module X = ME *)
+    | Pstr_recmodule of module_binding list
+    (* module rec X1 = ME1 and ... and Xn = MEn *)
+    | Pstr_modtype of module_type_declaration
+    (* module type S = MT *)
+    | Pstr_open of open_declaration
+    (* open X *)
+    | Pstr_class of class_declaration list
+    (* class c1 = ... and ... and cn = ... *)
+    | Pstr_class_type of class_type_declaration list
+    (* class type ct1 = ... and ... and ctn = ... *)
+    | Pstr_include of include_declaration
+    (* include ME *)
+    | Pstr_attribute of attribute
+    (* [@@@id] *)
+    | Pstr_extension of extension * attributes
+    (* [%%id] *)
+
+  and value_binding (*IF_CURRENT = Parsetree.value_binding *) =
+    {
+      pvb_pat: pattern;
+      pvb_expr: expression;
+      pvb_attributes: attributes;
+      pvb_loc: Location.t;
+    }
+
+  and module_binding (*IF_CURRENT = Parsetree.module_binding *) =
+    {
+      pmb_name: string option loc;
+      pmb_expr: module_expr;
+      pmb_attributes: attributes;
+      pmb_loc: Location.t;
+    }
+  (* X = ME *)
+
+  (** {1 Toplevel} *)
+
+  (* Toplevel phrases *)
+
+  type toplevel_phrase (*IF_CURRENT = Parsetree.toplevel_phrase *) =
+    | Ptop_def of structure
+    | Ptop_dir of toplevel_directive
+    (* #use, #load ... *)
+
+  and toplevel_directive (*IF_CURRENT = Parsetree.toplevel_directive *) =
+    {
+      pdir_name : string loc;
+      pdir_arg : directive_argument option;
+      pdir_loc : Location.t;
+    }
+
+  and directive_argument (*IF_CURRENT = Parsetree.directive_argument *) =
+    {
+      pdira_desc : directive_argument_desc;
+      pdira_loc : Location.t;
+    }
+
+  and directive_argument_desc (*IF_CURRENT = Parsetree.directive_argument_desc *) =
+    | Pdir_string of string
+    | Pdir_int of string * char option
+    | Pdir_ident of Longident.t
+    | Pdir_bool of bool
+end
+
+module Config = struct
+  let ast_impl_magic_number = "Caml1999M028"
+  let ast_intf_magic_number = "Caml1999N028"
+end

--- a/src/ast_412.ml
+++ b/src/ast_412.ml
@@ -54,11 +54,14 @@ module Asttypes = struct
     loc : Location.t;
   }
 
-
   type variance (*IF_CURRENT = Asttypes.variance *) =
     | Covariant
     | Contravariant
-    | Invariant
+    | NoVariance
+
+  type injectivity (*IF_CURRENT = Asttypes.injectivity *) =
+    | Injective
+    | NoInjectivity
 end
 
 module Parsetree = struct
@@ -471,7 +474,7 @@ module Parsetree = struct
   and type_declaration (*IF_CURRENT = Parsetree.type_declaration *) =
     {
       ptype_name: string loc;
-      ptype_params: (core_type * variance) list;
+      ptype_params: (core_type * (variance * injectivity)) list;
       (* ('a1,...'an) t; None represents  _*)
       ptype_cstrs: (core_type * core_type * Location.t) list;
       (* ... constraint T1=T1'  ... constraint Tn=Tn' *)
@@ -539,7 +542,7 @@ module Parsetree = struct
   and type_extension (*IF_CURRENT = Parsetree.type_extension *) =
     {
       ptyext_path: Longident.t loc;
-      ptyext_params: (core_type * variance) list;
+      ptyext_params: (core_type * (variance * injectivity)) list;
       ptyext_constructors: extension_constructor list;
       ptyext_private: private_flag;
       ptyext_loc: Location.t;
@@ -640,7 +643,7 @@ module Parsetree = struct
   and 'a class_infos (*IF_CURRENT = 'a Parsetree.class_infos *) =
     {
       pci_virt: virtual_flag;
-      pci_params: (core_type * variance) list;
+      pci_params: (core_type * (variance * injectivity)) list;
       pci_name: string loc;
       pci_expr: 'a;
       pci_loc: Location.t;

--- a/src/ast_412.ml
+++ b/src/ast_412.ml
@@ -1016,6 +1016,6 @@ module Parsetree = struct
 end
 
 module Config = struct
-  let ast_impl_magic_number = "Caml1999M027"
-  let ast_intf_magic_number = "Caml1999N027"
+  let ast_impl_magic_number = "Caml1999M029"
+  let ast_intf_magic_number = "Caml1999N029"
 end

--- a/src/ast_412.ml
+++ b/src/ast_412.ml
@@ -1016,6 +1016,6 @@ module Parsetree = struct
 end
 
 module Config = struct
-  let ast_impl_magic_number = "Caml1999M028"
-  let ast_intf_magic_number = "Caml1999N028"
+  let ast_impl_magic_number = "Caml1999M027"
+  let ast_intf_magic_number = "Caml1999N027"
 end

--- a/src/cinaps_helpers/cinaps_helpers.ml
+++ b/src/cinaps_helpers/cinaps_helpers.ml
@@ -16,6 +16,7 @@ let supported_versions = [
   ("409", "4.09");
   ("410", "4.10");
   ("411", "4.11");
+  ("412", "4.12");
 ]
 
 let foreach_version f =

--- a/src/config/gen.ml
+++ b/src/config/gen.ml
@@ -20,6 +20,7 @@ let () =
      | (4, 09) -> "409"
      | (4, 10) -> "410"
      | (4, 11) -> "411"
+     | (4, 12) -> "412"
      | _ ->
-       Printf.eprintf "Unkown OCaml version %s\n" ocaml_version_str;
+       Printf.eprintf "Unknown OCaml version %s\n" ocaml_version_str;
        exit 1)

--- a/src/migrate_411_412.ml
+++ b/src/migrate_411_412.ml
@@ -1179,5 +1179,3 @@ and copy_loc :
       }
 and copy_location : Location.t -> Location.t =
   fun x -> x
-and copy_position : Stdlib.Lexing.position -> Stdlib.Lexing.position =
-  fun x -> x

--- a/src/migrate_411_412.ml
+++ b/src/migrate_411_412.ml
@@ -830,7 +830,8 @@ and copy_class_infos :
         Ast_412.Parsetree.pci_params =
           (List.map
              (fun x ->
-                let (x0, x1) = x in ((copy_core_type x0), (copy_variance x1)))
+                let (x0, x1) = x in
+                ((copy_core_type x0), (copy_variance x1, Ast_412.Asttypes.NoInjectivity)))
              pci_params);
         Ast_412.Parsetree.pci_name = (copy_loc (fun x -> x) pci_name);
         Ast_412.Parsetree.pci_expr = (f0 pci_expr);
@@ -971,7 +972,8 @@ and copy_type_extension :
       Ast_412.Parsetree.ptyext_params =
         (List.map
            (fun x ->
-              let (x0, x1) = x in ((copy_core_type x0), (copy_variance x1)))
+              let (x0, x1) = x in
+              ((copy_core_type x0), (copy_variance x1, Ast_412.Asttypes.NoInjectivity)))
            ptyext_params);
       Ast_412.Parsetree.ptyext_constructors =
         (List.map copy_extension_constructor ptyext_constructors);
@@ -1024,7 +1026,8 @@ and copy_type_declaration :
       Ast_412.Parsetree.ptype_params =
         (List.map
            (fun x ->
-              let (x0, x1) = x in ((copy_core_type x0), (copy_variance x1)))
+              let (x0, x1) = x in
+              ((copy_core_type x0), (copy_variance x1, Ast_412.Asttypes.NoInjectivity)))
            ptype_params);
       Ast_412.Parsetree.ptype_cstrs =
         (List.map
@@ -1107,7 +1110,7 @@ and copy_variance : Ast_411.Asttypes.variance -> Ast_412.Asttypes.variance =
   function
   | Ast_411.Asttypes.Covariant -> Ast_412.Asttypes.Covariant
   | Ast_411.Asttypes.Contravariant -> Ast_412.Asttypes.Contravariant
-  | Ast_411.Asttypes.Invariant -> Ast_412.Asttypes.Invariant
+  | Ast_411.Asttypes.Invariant -> Ast_412.Asttypes.NoVariance
 and copy_value_description :
   Ast_411.Parsetree.value_description -> Ast_412.Parsetree.value_description
   =

--- a/src/migrate_411_412.ml
+++ b/src/migrate_411_412.ml
@@ -1,3 +1,4 @@
+open Stdlib0
 module From = Ast_411
 module To = Ast_412
 let rec copy_toplevel_phrase :

--- a/src/migrate_411_412.ml
+++ b/src/migrate_411_412.ml
@@ -1,0 +1,1200 @@
+module From = Ast_411
+module To = Ast_412
+let rec copy_toplevel_phrase :
+  Ast_411.Parsetree.toplevel_phrase -> Ast_412.Parsetree.toplevel_phrase =
+  function
+  | Ast_411.Parsetree.Ptop_def x0 ->
+      Ast_412.Parsetree.Ptop_def (copy_structure x0)
+  | Ast_411.Parsetree.Ptop_dir x0 ->
+      Ast_412.Parsetree.Ptop_dir (copy_toplevel_directive x0)
+and copy_toplevel_directive :
+  Ast_411.Parsetree.toplevel_directive ->
+    Ast_412.Parsetree.toplevel_directive
+  =
+  fun
+    { Ast_411.Parsetree.pdir_name = pdir_name;
+      Ast_411.Parsetree.pdir_arg = pdir_arg;
+      Ast_411.Parsetree.pdir_loc = pdir_loc }
+    ->
+    {
+      Ast_412.Parsetree.pdir_name = (copy_loc (fun x -> x) pdir_name);
+      Ast_412.Parsetree.pdir_arg =
+        (Option.map copy_directive_argument pdir_arg);
+      Ast_412.Parsetree.pdir_loc = (copy_location pdir_loc)
+    }
+and copy_directive_argument :
+  Ast_411.Parsetree.directive_argument ->
+    Ast_412.Parsetree.directive_argument
+  =
+  fun
+    { Ast_411.Parsetree.pdira_desc = pdira_desc;
+      Ast_411.Parsetree.pdira_loc = pdira_loc }
+    ->
+    {
+      Ast_412.Parsetree.pdira_desc =
+        (copy_directive_argument_desc pdira_desc);
+      Ast_412.Parsetree.pdira_loc = (copy_location pdira_loc)
+    }
+and copy_directive_argument_desc :
+  Ast_411.Parsetree.directive_argument_desc ->
+    Ast_412.Parsetree.directive_argument_desc
+  =
+  function
+  | Ast_411.Parsetree.Pdir_string x0 -> Ast_412.Parsetree.Pdir_string x0
+  | Ast_411.Parsetree.Pdir_int (x0, x1) ->
+      Ast_412.Parsetree.Pdir_int (x0, (Option.map (fun x -> x) x1))
+  | Ast_411.Parsetree.Pdir_ident x0 ->
+      Ast_412.Parsetree.Pdir_ident (copy_Longident_t x0)
+  | Ast_411.Parsetree.Pdir_bool x0 -> Ast_412.Parsetree.Pdir_bool x0
+and copy_expression :
+  Ast_411.Parsetree.expression -> Ast_412.Parsetree.expression =
+  fun
+    { Ast_411.Parsetree.pexp_desc = pexp_desc;
+      Ast_411.Parsetree.pexp_loc = pexp_loc;
+      Ast_411.Parsetree.pexp_loc_stack = pexp_loc_stack;
+      Ast_411.Parsetree.pexp_attributes = pexp_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pexp_desc = (copy_expression_desc pexp_desc);
+      Ast_412.Parsetree.pexp_loc = (copy_location pexp_loc);
+      Ast_412.Parsetree.pexp_loc_stack = (copy_location_stack pexp_loc_stack);
+      Ast_412.Parsetree.pexp_attributes = (copy_attributes pexp_attributes)
+    }
+and copy_expression_desc :
+  Ast_411.Parsetree.expression_desc -> Ast_412.Parsetree.expression_desc =
+  function
+  | Ast_411.Parsetree.Pexp_ident x0 ->
+      Ast_412.Parsetree.Pexp_ident (copy_loc copy_Longident_t x0)
+  | Ast_411.Parsetree.Pexp_constant x0 ->
+      Ast_412.Parsetree.Pexp_constant (copy_constant x0)
+  | Ast_411.Parsetree.Pexp_let (x0, x1, x2) ->
+      Ast_412.Parsetree.Pexp_let
+        ((copy_rec_flag x0), (List.map copy_value_binding x1),
+          (copy_expression x2))
+  | Ast_411.Parsetree.Pexp_function x0 ->
+      Ast_412.Parsetree.Pexp_function (List.map copy_case x0)
+  | Ast_411.Parsetree.Pexp_fun (x0, x1, x2, x3) ->
+      Ast_412.Parsetree.Pexp_fun
+        ((copy_arg_label x0), (Option.map copy_expression x1),
+          (copy_pattern x2), (copy_expression x3))
+  | Ast_411.Parsetree.Pexp_apply (x0, x1) ->
+      Ast_412.Parsetree.Pexp_apply
+        ((copy_expression x0),
+          (List.map
+             (fun x ->
+                let (x0, x1) = x in
+                ((copy_arg_label x0), (copy_expression x1))) x1))
+  | Ast_411.Parsetree.Pexp_match (x0, x1) ->
+      Ast_412.Parsetree.Pexp_match
+        ((copy_expression x0), (List.map copy_case x1))
+  | Ast_411.Parsetree.Pexp_try (x0, x1) ->
+      Ast_412.Parsetree.Pexp_try
+        ((copy_expression x0), (List.map copy_case x1))
+  | Ast_411.Parsetree.Pexp_tuple x0 ->
+      Ast_412.Parsetree.Pexp_tuple (List.map copy_expression x0)
+  | Ast_411.Parsetree.Pexp_construct (x0, x1) ->
+      Ast_412.Parsetree.Pexp_construct
+        ((copy_loc copy_Longident_t x0), (Option.map copy_expression x1))
+  | Ast_411.Parsetree.Pexp_variant (x0, x1) ->
+      Ast_412.Parsetree.Pexp_variant
+        ((copy_label x0), (Option.map copy_expression x1))
+  | Ast_411.Parsetree.Pexp_record (x0, x1) ->
+      Ast_412.Parsetree.Pexp_record
+        ((List.map
+            (fun x ->
+               let (x0, x1) = x in
+               ((copy_loc copy_Longident_t x0), (copy_expression x1))) x0),
+          (Option.map copy_expression x1))
+  | Ast_411.Parsetree.Pexp_field (x0, x1) ->
+      Ast_412.Parsetree.Pexp_field
+        ((copy_expression x0), (copy_loc copy_Longident_t x1))
+  | Ast_411.Parsetree.Pexp_setfield (x0, x1, x2) ->
+      Ast_412.Parsetree.Pexp_setfield
+        ((copy_expression x0), (copy_loc copy_Longident_t x1),
+          (copy_expression x2))
+  | Ast_411.Parsetree.Pexp_array x0 ->
+      Ast_412.Parsetree.Pexp_array (List.map copy_expression x0)
+  | Ast_411.Parsetree.Pexp_ifthenelse (x0, x1, x2) ->
+      Ast_412.Parsetree.Pexp_ifthenelse
+        ((copy_expression x0), (copy_expression x1),
+          (Option.map copy_expression x2))
+  | Ast_411.Parsetree.Pexp_sequence (x0, x1) ->
+      Ast_412.Parsetree.Pexp_sequence
+        ((copy_expression x0), (copy_expression x1))
+  | Ast_411.Parsetree.Pexp_while (x0, x1) ->
+      Ast_412.Parsetree.Pexp_while
+        ((copy_expression x0), (copy_expression x1))
+  | Ast_411.Parsetree.Pexp_for (x0, x1, x2, x3, x4) ->
+      Ast_412.Parsetree.Pexp_for
+        ((copy_pattern x0), (copy_expression x1), (copy_expression x2),
+          (copy_direction_flag x3), (copy_expression x4))
+  | Ast_411.Parsetree.Pexp_constraint (x0, x1) ->
+      Ast_412.Parsetree.Pexp_constraint
+        ((copy_expression x0), (copy_core_type x1))
+  | Ast_411.Parsetree.Pexp_coerce (x0, x1, x2) ->
+      Ast_412.Parsetree.Pexp_coerce
+        ((copy_expression x0), (Option.map copy_core_type x1),
+          (copy_core_type x2))
+  | Ast_411.Parsetree.Pexp_send (x0, x1) ->
+      Ast_412.Parsetree.Pexp_send
+        ((copy_expression x0), (copy_loc copy_label x1))
+  | Ast_411.Parsetree.Pexp_new x0 ->
+      Ast_412.Parsetree.Pexp_new (copy_loc copy_Longident_t x0)
+  | Ast_411.Parsetree.Pexp_setinstvar (x0, x1) ->
+      Ast_412.Parsetree.Pexp_setinstvar
+        ((copy_loc copy_label x0), (copy_expression x1))
+  | Ast_411.Parsetree.Pexp_override x0 ->
+      Ast_412.Parsetree.Pexp_override
+        (List.map
+           (fun x ->
+              let (x0, x1) = x in
+              ((copy_loc copy_label x0), (copy_expression x1))) x0)
+  | Ast_411.Parsetree.Pexp_letmodule (x0, x1, x2) ->
+      Ast_412.Parsetree.Pexp_letmodule
+        ((copy_loc (fun x -> Option.map (fun x -> x) x) x0),
+          (copy_module_expr x1), (copy_expression x2))
+  | Ast_411.Parsetree.Pexp_letexception (x0, x1) ->
+      Ast_412.Parsetree.Pexp_letexception
+        ((copy_extension_constructor x0), (copy_expression x1))
+  | Ast_411.Parsetree.Pexp_assert x0 ->
+      Ast_412.Parsetree.Pexp_assert (copy_expression x0)
+  | Ast_411.Parsetree.Pexp_lazy x0 ->
+      Ast_412.Parsetree.Pexp_lazy (copy_expression x0)
+  | Ast_411.Parsetree.Pexp_poly (x0, x1) ->
+      Ast_412.Parsetree.Pexp_poly
+        ((copy_expression x0), (Option.map copy_core_type x1))
+  | Ast_411.Parsetree.Pexp_object x0 ->
+      Ast_412.Parsetree.Pexp_object (copy_class_structure x0)
+  | Ast_411.Parsetree.Pexp_newtype (x0, x1) ->
+      Ast_412.Parsetree.Pexp_newtype
+        ((copy_loc (fun x -> x) x0), (copy_expression x1))
+  | Ast_411.Parsetree.Pexp_pack x0 ->
+      Ast_412.Parsetree.Pexp_pack (copy_module_expr x0)
+  | Ast_411.Parsetree.Pexp_open (x0, x1) ->
+      Ast_412.Parsetree.Pexp_open
+        ((copy_open_declaration x0), (copy_expression x1))
+  | Ast_411.Parsetree.Pexp_letop x0 ->
+      Ast_412.Parsetree.Pexp_letop (copy_letop x0)
+  | Ast_411.Parsetree.Pexp_extension x0 ->
+      Ast_412.Parsetree.Pexp_extension (copy_extension x0)
+  | Ast_411.Parsetree.Pexp_unreachable -> Ast_412.Parsetree.Pexp_unreachable
+and copy_letop : Ast_411.Parsetree.letop -> Ast_412.Parsetree.letop =
+  fun
+    { Ast_411.Parsetree.let_ = let_; Ast_411.Parsetree.ands = ands;
+      Ast_411.Parsetree.body = body }
+    ->
+    {
+      Ast_412.Parsetree.let_ = (copy_binding_op let_);
+      Ast_412.Parsetree.ands = (List.map copy_binding_op ands);
+      Ast_412.Parsetree.body = (copy_expression body)
+    }
+and copy_binding_op :
+  Ast_411.Parsetree.binding_op -> Ast_412.Parsetree.binding_op =
+  fun
+    { Ast_411.Parsetree.pbop_op = pbop_op;
+      Ast_411.Parsetree.pbop_pat = pbop_pat;
+      Ast_411.Parsetree.pbop_exp = pbop_exp;
+      Ast_411.Parsetree.pbop_loc = pbop_loc }
+    ->
+    {
+      Ast_412.Parsetree.pbop_op = (copy_loc (fun x -> x) pbop_op);
+      Ast_412.Parsetree.pbop_pat = (copy_pattern pbop_pat);
+      Ast_412.Parsetree.pbop_exp = (copy_expression pbop_exp);
+      Ast_412.Parsetree.pbop_loc = (copy_location pbop_loc)
+    }
+and copy_direction_flag :
+  Ast_411.Asttypes.direction_flag -> Ast_412.Asttypes.direction_flag =
+  function
+  | Ast_411.Asttypes.Upto -> Ast_412.Asttypes.Upto
+  | Ast_411.Asttypes.Downto -> Ast_412.Asttypes.Downto
+and copy_case : Ast_411.Parsetree.case -> Ast_412.Parsetree.case =
+  fun
+    { Ast_411.Parsetree.pc_lhs = pc_lhs;
+      Ast_411.Parsetree.pc_guard = pc_guard;
+      Ast_411.Parsetree.pc_rhs = pc_rhs }
+    ->
+    {
+      Ast_412.Parsetree.pc_lhs = (copy_pattern pc_lhs);
+      Ast_412.Parsetree.pc_guard = (Option.map copy_expression pc_guard);
+      Ast_412.Parsetree.pc_rhs = (copy_expression pc_rhs)
+    }
+and copy_value_binding :
+  Ast_411.Parsetree.value_binding -> Ast_412.Parsetree.value_binding =
+  fun
+    { Ast_411.Parsetree.pvb_pat = pvb_pat;
+      Ast_411.Parsetree.pvb_expr = pvb_expr;
+      Ast_411.Parsetree.pvb_attributes = pvb_attributes;
+      Ast_411.Parsetree.pvb_loc = pvb_loc }
+    ->
+    {
+      Ast_412.Parsetree.pvb_pat = (copy_pattern pvb_pat);
+      Ast_412.Parsetree.pvb_expr = (copy_expression pvb_expr);
+      Ast_412.Parsetree.pvb_attributes = (copy_attributes pvb_attributes);
+      Ast_412.Parsetree.pvb_loc = (copy_location pvb_loc)
+    }
+and copy_pattern : Ast_411.Parsetree.pattern -> Ast_412.Parsetree.pattern =
+  fun
+    { Ast_411.Parsetree.ppat_desc = ppat_desc;
+      Ast_411.Parsetree.ppat_loc = ppat_loc;
+      Ast_411.Parsetree.ppat_loc_stack = ppat_loc_stack;
+      Ast_411.Parsetree.ppat_attributes = ppat_attributes }
+    ->
+    {
+      Ast_412.Parsetree.ppat_desc = (copy_pattern_desc ppat_desc);
+      Ast_412.Parsetree.ppat_loc = (copy_location ppat_loc);
+      Ast_412.Parsetree.ppat_loc_stack = (copy_location_stack ppat_loc_stack);
+      Ast_412.Parsetree.ppat_attributes = (copy_attributes ppat_attributes)
+    }
+and copy_pattern_desc :
+  Ast_411.Parsetree.pattern_desc -> Ast_412.Parsetree.pattern_desc =
+  function
+  | Ast_411.Parsetree.Ppat_any -> Ast_412.Parsetree.Ppat_any
+  | Ast_411.Parsetree.Ppat_var x0 ->
+      Ast_412.Parsetree.Ppat_var (copy_loc (fun x -> x) x0)
+  | Ast_411.Parsetree.Ppat_alias (x0, x1) ->
+      Ast_412.Parsetree.Ppat_alias
+        ((copy_pattern x0), (copy_loc (fun x -> x) x1))
+  | Ast_411.Parsetree.Ppat_constant x0 ->
+      Ast_412.Parsetree.Ppat_constant (copy_constant x0)
+  | Ast_411.Parsetree.Ppat_interval (x0, x1) ->
+      Ast_412.Parsetree.Ppat_interval
+        ((copy_constant x0), (copy_constant x1))
+  | Ast_411.Parsetree.Ppat_tuple x0 ->
+      Ast_412.Parsetree.Ppat_tuple (List.map copy_pattern x0)
+  | Ast_411.Parsetree.Ppat_construct (x0, x1) ->
+      Ast_412.Parsetree.Ppat_construct
+        ((copy_loc copy_Longident_t x0), (Option.map copy_pattern x1))
+  | Ast_411.Parsetree.Ppat_variant (x0, x1) ->
+      Ast_412.Parsetree.Ppat_variant
+        ((copy_label x0), (Option.map copy_pattern x1))
+  | Ast_411.Parsetree.Ppat_record (x0, x1) ->
+      Ast_412.Parsetree.Ppat_record
+        ((List.map
+            (fun x ->
+               let (x0, x1) = x in
+               ((copy_loc copy_Longident_t x0), (copy_pattern x1))) x0),
+          (copy_closed_flag x1))
+  | Ast_411.Parsetree.Ppat_array x0 ->
+      Ast_412.Parsetree.Ppat_array (List.map copy_pattern x0)
+  | Ast_411.Parsetree.Ppat_or (x0, x1) ->
+      Ast_412.Parsetree.Ppat_or ((copy_pattern x0), (copy_pattern x1))
+  | Ast_411.Parsetree.Ppat_constraint (x0, x1) ->
+      Ast_412.Parsetree.Ppat_constraint
+        ((copy_pattern x0), (copy_core_type x1))
+  | Ast_411.Parsetree.Ppat_type x0 ->
+      Ast_412.Parsetree.Ppat_type (copy_loc copy_Longident_t x0)
+  | Ast_411.Parsetree.Ppat_lazy x0 ->
+      Ast_412.Parsetree.Ppat_lazy (copy_pattern x0)
+  | Ast_411.Parsetree.Ppat_unpack x0 ->
+      Ast_412.Parsetree.Ppat_unpack
+        (copy_loc (fun x -> Option.map (fun x -> x) x) x0)
+  | Ast_411.Parsetree.Ppat_exception x0 ->
+      Ast_412.Parsetree.Ppat_exception (copy_pattern x0)
+  | Ast_411.Parsetree.Ppat_extension x0 ->
+      Ast_412.Parsetree.Ppat_extension (copy_extension x0)
+  | Ast_411.Parsetree.Ppat_open (x0, x1) ->
+      Ast_412.Parsetree.Ppat_open
+        ((copy_loc copy_Longident_t x0), (copy_pattern x1))
+and copy_core_type :
+  Ast_411.Parsetree.core_type -> Ast_412.Parsetree.core_type =
+  fun
+    { Ast_411.Parsetree.ptyp_desc = ptyp_desc;
+      Ast_411.Parsetree.ptyp_loc = ptyp_loc;
+      Ast_411.Parsetree.ptyp_loc_stack = ptyp_loc_stack;
+      Ast_411.Parsetree.ptyp_attributes = ptyp_attributes }
+    ->
+    {
+      Ast_412.Parsetree.ptyp_desc = (copy_core_type_desc ptyp_desc);
+      Ast_412.Parsetree.ptyp_loc = (copy_location ptyp_loc);
+      Ast_412.Parsetree.ptyp_loc_stack = (copy_location_stack ptyp_loc_stack);
+      Ast_412.Parsetree.ptyp_attributes = (copy_attributes ptyp_attributes)
+    }
+and copy_location_stack :
+  Ast_411.Parsetree.location_stack -> Ast_412.Parsetree.location_stack =
+  fun x -> List.map copy_location x
+and copy_core_type_desc :
+  Ast_411.Parsetree.core_type_desc -> Ast_412.Parsetree.core_type_desc =
+  function
+  | Ast_411.Parsetree.Ptyp_any -> Ast_412.Parsetree.Ptyp_any
+  | Ast_411.Parsetree.Ptyp_var x0 -> Ast_412.Parsetree.Ptyp_var x0
+  | Ast_411.Parsetree.Ptyp_arrow (x0, x1, x2) ->
+      Ast_412.Parsetree.Ptyp_arrow
+        ((copy_arg_label x0), (copy_core_type x1), (copy_core_type x2))
+  | Ast_411.Parsetree.Ptyp_tuple x0 ->
+      Ast_412.Parsetree.Ptyp_tuple (List.map copy_core_type x0)
+  | Ast_411.Parsetree.Ptyp_constr (x0, x1) ->
+      Ast_412.Parsetree.Ptyp_constr
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_411.Parsetree.Ptyp_object (x0, x1) ->
+      Ast_412.Parsetree.Ptyp_object
+        ((List.map copy_object_field x0), (copy_closed_flag x1))
+  | Ast_411.Parsetree.Ptyp_class (x0, x1) ->
+      Ast_412.Parsetree.Ptyp_class
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_411.Parsetree.Ptyp_alias (x0, x1) ->
+      Ast_412.Parsetree.Ptyp_alias ((copy_core_type x0), x1)
+  | Ast_411.Parsetree.Ptyp_variant (x0, x1, x2) ->
+      Ast_412.Parsetree.Ptyp_variant
+        ((List.map copy_row_field x0), (copy_closed_flag x1),
+          (Option.map (fun x -> List.map copy_label x) x2))
+  | Ast_411.Parsetree.Ptyp_poly (x0, x1) ->
+      Ast_412.Parsetree.Ptyp_poly
+        ((List.map (fun x -> copy_loc (fun x -> x) x) x0),
+          (copy_core_type x1))
+  | Ast_411.Parsetree.Ptyp_package x0 ->
+      Ast_412.Parsetree.Ptyp_package (copy_package_type x0)
+  | Ast_411.Parsetree.Ptyp_extension x0 ->
+      Ast_412.Parsetree.Ptyp_extension (copy_extension x0)
+and copy_package_type :
+  Ast_411.Parsetree.package_type -> Ast_412.Parsetree.package_type =
+  fun x ->
+    let (x0, x1) = x in
+    ((copy_loc copy_Longident_t x0),
+      (List.map
+         (fun x ->
+            let (x0, x1) = x in
+            ((copy_loc copy_Longident_t x0), (copy_core_type x1))) x1))
+and copy_row_field :
+  Ast_411.Parsetree.row_field -> Ast_412.Parsetree.row_field =
+  fun
+    { Ast_411.Parsetree.prf_desc = prf_desc;
+      Ast_411.Parsetree.prf_loc = prf_loc;
+      Ast_411.Parsetree.prf_attributes = prf_attributes }
+    ->
+    {
+      Ast_412.Parsetree.prf_desc = (copy_row_field_desc prf_desc);
+      Ast_412.Parsetree.prf_loc = (copy_location prf_loc);
+      Ast_412.Parsetree.prf_attributes = (copy_attributes prf_attributes)
+    }
+and copy_row_field_desc :
+  Ast_411.Parsetree.row_field_desc -> Ast_412.Parsetree.row_field_desc =
+  function
+  | Ast_411.Parsetree.Rtag (x0, x1, x2) ->
+      Ast_412.Parsetree.Rtag
+        ((copy_loc copy_label x0), x1, (List.map copy_core_type x2))
+  | Ast_411.Parsetree.Rinherit x0 ->
+      Ast_412.Parsetree.Rinherit (copy_core_type x0)
+and copy_object_field :
+  Ast_411.Parsetree.object_field -> Ast_412.Parsetree.object_field =
+  fun
+    { Ast_411.Parsetree.pof_desc = pof_desc;
+      Ast_411.Parsetree.pof_loc = pof_loc;
+      Ast_411.Parsetree.pof_attributes = pof_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pof_desc = (copy_object_field_desc pof_desc);
+      Ast_412.Parsetree.pof_loc = (copy_location pof_loc);
+      Ast_412.Parsetree.pof_attributes = (copy_attributes pof_attributes)
+    }
+and copy_attributes :
+  Ast_411.Parsetree.attributes -> Ast_412.Parsetree.attributes =
+  fun x -> List.map copy_attribute x
+and copy_attribute :
+  Ast_411.Parsetree.attribute -> Ast_412.Parsetree.attribute =
+  fun
+    { Ast_411.Parsetree.attr_name = attr_name;
+      Ast_411.Parsetree.attr_payload = attr_payload;
+      Ast_411.Parsetree.attr_loc = attr_loc }
+    ->
+    {
+      Ast_412.Parsetree.attr_name = (copy_loc (fun x -> x) attr_name);
+      Ast_412.Parsetree.attr_payload = (copy_payload attr_payload);
+      Ast_412.Parsetree.attr_loc = (copy_location attr_loc)
+    }
+and copy_payload : Ast_411.Parsetree.payload -> Ast_412.Parsetree.payload =
+  function
+  | Ast_411.Parsetree.PStr x0 -> Ast_412.Parsetree.PStr (copy_structure x0)
+  | Ast_411.Parsetree.PSig x0 -> Ast_412.Parsetree.PSig (copy_signature x0)
+  | Ast_411.Parsetree.PTyp x0 -> Ast_412.Parsetree.PTyp (copy_core_type x0)
+  | Ast_411.Parsetree.PPat (x0, x1) ->
+      Ast_412.Parsetree.PPat
+        ((copy_pattern x0), (Option.map copy_expression x1))
+and copy_structure :
+  Ast_411.Parsetree.structure -> Ast_412.Parsetree.structure =
+  fun x -> List.map copy_structure_item x
+and copy_structure_item :
+  Ast_411.Parsetree.structure_item -> Ast_412.Parsetree.structure_item =
+  fun
+    { Ast_411.Parsetree.pstr_desc = pstr_desc;
+      Ast_411.Parsetree.pstr_loc = pstr_loc }
+    ->
+    {
+      Ast_412.Parsetree.pstr_desc = (copy_structure_item_desc pstr_desc);
+      Ast_412.Parsetree.pstr_loc = (copy_location pstr_loc)
+    }
+and copy_structure_item_desc :
+  Ast_411.Parsetree.structure_item_desc ->
+    Ast_412.Parsetree.structure_item_desc
+  =
+  function
+  | Ast_411.Parsetree.Pstr_eval (x0, x1) ->
+      Ast_412.Parsetree.Pstr_eval
+        ((copy_expression x0), (copy_attributes x1))
+  | Ast_411.Parsetree.Pstr_value (x0, x1) ->
+      Ast_412.Parsetree.Pstr_value
+        ((copy_rec_flag x0), (List.map copy_value_binding x1))
+  | Ast_411.Parsetree.Pstr_primitive x0 ->
+      Ast_412.Parsetree.Pstr_primitive (copy_value_description x0)
+  | Ast_411.Parsetree.Pstr_type (x0, x1) ->
+      Ast_412.Parsetree.Pstr_type
+        ((copy_rec_flag x0), (List.map copy_type_declaration x1))
+  | Ast_411.Parsetree.Pstr_typext x0 ->
+      Ast_412.Parsetree.Pstr_typext (copy_type_extension x0)
+  | Ast_411.Parsetree.Pstr_exception x0 ->
+      Ast_412.Parsetree.Pstr_exception (copy_type_exception x0)
+  | Ast_411.Parsetree.Pstr_module x0 ->
+      Ast_412.Parsetree.Pstr_module (copy_module_binding x0)
+  | Ast_411.Parsetree.Pstr_recmodule x0 ->
+      Ast_412.Parsetree.Pstr_recmodule (List.map copy_module_binding x0)
+  | Ast_411.Parsetree.Pstr_modtype x0 ->
+      Ast_412.Parsetree.Pstr_modtype (copy_module_type_declaration x0)
+  | Ast_411.Parsetree.Pstr_open x0 ->
+      Ast_412.Parsetree.Pstr_open (copy_open_declaration x0)
+  | Ast_411.Parsetree.Pstr_class x0 ->
+      Ast_412.Parsetree.Pstr_class (List.map copy_class_declaration x0)
+  | Ast_411.Parsetree.Pstr_class_type x0 ->
+      Ast_412.Parsetree.Pstr_class_type
+        (List.map copy_class_type_declaration x0)
+  | Ast_411.Parsetree.Pstr_include x0 ->
+      Ast_412.Parsetree.Pstr_include (copy_include_declaration x0)
+  | Ast_411.Parsetree.Pstr_attribute x0 ->
+      Ast_412.Parsetree.Pstr_attribute (copy_attribute x0)
+  | Ast_411.Parsetree.Pstr_extension (x0, x1) ->
+      Ast_412.Parsetree.Pstr_extension
+        ((copy_extension x0), (copy_attributes x1))
+and copy_include_declaration :
+  Ast_411.Parsetree.include_declaration ->
+    Ast_412.Parsetree.include_declaration
+  = fun x -> copy_include_infos copy_module_expr x
+and copy_class_declaration :
+  Ast_411.Parsetree.class_declaration -> Ast_412.Parsetree.class_declaration
+  = fun x -> copy_class_infos copy_class_expr x
+and copy_class_expr :
+  Ast_411.Parsetree.class_expr -> Ast_412.Parsetree.class_expr =
+  fun
+    { Ast_411.Parsetree.pcl_desc = pcl_desc;
+      Ast_411.Parsetree.pcl_loc = pcl_loc;
+      Ast_411.Parsetree.pcl_attributes = pcl_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pcl_desc = (copy_class_expr_desc pcl_desc);
+      Ast_412.Parsetree.pcl_loc = (copy_location pcl_loc);
+      Ast_412.Parsetree.pcl_attributes = (copy_attributes pcl_attributes)
+    }
+and copy_class_expr_desc :
+  Ast_411.Parsetree.class_expr_desc -> Ast_412.Parsetree.class_expr_desc =
+  function
+  | Ast_411.Parsetree.Pcl_constr (x0, x1) ->
+      Ast_412.Parsetree.Pcl_constr
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_411.Parsetree.Pcl_structure x0 ->
+      Ast_412.Parsetree.Pcl_structure (copy_class_structure x0)
+  | Ast_411.Parsetree.Pcl_fun (x0, x1, x2, x3) ->
+      Ast_412.Parsetree.Pcl_fun
+        ((copy_arg_label x0), (Option.map copy_expression x1),
+          (copy_pattern x2), (copy_class_expr x3))
+  | Ast_411.Parsetree.Pcl_apply (x0, x1) ->
+      Ast_412.Parsetree.Pcl_apply
+        ((copy_class_expr x0),
+          (List.map
+             (fun x ->
+                let (x0, x1) = x in
+                ((copy_arg_label x0), (copy_expression x1))) x1))
+  | Ast_411.Parsetree.Pcl_let (x0, x1, x2) ->
+      Ast_412.Parsetree.Pcl_let
+        ((copy_rec_flag x0), (List.map copy_value_binding x1),
+          (copy_class_expr x2))
+  | Ast_411.Parsetree.Pcl_constraint (x0, x1) ->
+      Ast_412.Parsetree.Pcl_constraint
+        ((copy_class_expr x0), (copy_class_type x1))
+  | Ast_411.Parsetree.Pcl_extension x0 ->
+      Ast_412.Parsetree.Pcl_extension (copy_extension x0)
+  | Ast_411.Parsetree.Pcl_open (x0, x1) ->
+      Ast_412.Parsetree.Pcl_open
+        ((copy_open_description x0), (copy_class_expr x1))
+and copy_class_structure :
+  Ast_411.Parsetree.class_structure -> Ast_412.Parsetree.class_structure =
+  fun
+    { Ast_411.Parsetree.pcstr_self = pcstr_self;
+      Ast_411.Parsetree.pcstr_fields = pcstr_fields }
+    ->
+    {
+      Ast_412.Parsetree.pcstr_self = (copy_pattern pcstr_self);
+      Ast_412.Parsetree.pcstr_fields =
+        (List.map copy_class_field pcstr_fields)
+    }
+and copy_class_field :
+  Ast_411.Parsetree.class_field -> Ast_412.Parsetree.class_field =
+  fun
+    { Ast_411.Parsetree.pcf_desc = pcf_desc;
+      Ast_411.Parsetree.pcf_loc = pcf_loc;
+      Ast_411.Parsetree.pcf_attributes = pcf_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pcf_desc = (copy_class_field_desc pcf_desc);
+      Ast_412.Parsetree.pcf_loc = (copy_location pcf_loc);
+      Ast_412.Parsetree.pcf_attributes = (copy_attributes pcf_attributes)
+    }
+and copy_class_field_desc :
+  Ast_411.Parsetree.class_field_desc -> Ast_412.Parsetree.class_field_desc =
+  function
+  | Ast_411.Parsetree.Pcf_inherit (x0, x1, x2) ->
+      Ast_412.Parsetree.Pcf_inherit
+        ((copy_override_flag x0), (copy_class_expr x1),
+          (Option.map (fun x -> copy_loc (fun x -> x) x) x2))
+  | Ast_411.Parsetree.Pcf_val x0 ->
+      Ast_412.Parsetree.Pcf_val
+        (let (x0, x1, x2) = x0 in
+         ((copy_loc copy_label x0), (copy_mutable_flag x1),
+           (copy_class_field_kind x2)))
+  | Ast_411.Parsetree.Pcf_method x0 ->
+      Ast_412.Parsetree.Pcf_method
+        (let (x0, x1, x2) = x0 in
+         ((copy_loc copy_label x0), (copy_private_flag x1),
+           (copy_class_field_kind x2)))
+  | Ast_411.Parsetree.Pcf_constraint x0 ->
+      Ast_412.Parsetree.Pcf_constraint
+        (let (x0, x1) = x0 in ((copy_core_type x0), (copy_core_type x1)))
+  | Ast_411.Parsetree.Pcf_initializer x0 ->
+      Ast_412.Parsetree.Pcf_initializer (copy_expression x0)
+  | Ast_411.Parsetree.Pcf_attribute x0 ->
+      Ast_412.Parsetree.Pcf_attribute (copy_attribute x0)
+  | Ast_411.Parsetree.Pcf_extension x0 ->
+      Ast_412.Parsetree.Pcf_extension (copy_extension x0)
+and copy_class_field_kind :
+  Ast_411.Parsetree.class_field_kind -> Ast_412.Parsetree.class_field_kind =
+  function
+  | Ast_411.Parsetree.Cfk_virtual x0 ->
+      Ast_412.Parsetree.Cfk_virtual (copy_core_type x0)
+  | Ast_411.Parsetree.Cfk_concrete (x0, x1) ->
+      Ast_412.Parsetree.Cfk_concrete
+        ((copy_override_flag x0), (copy_expression x1))
+and copy_open_declaration :
+  Ast_411.Parsetree.open_declaration -> Ast_412.Parsetree.open_declaration =
+  fun x -> copy_open_infos copy_module_expr x
+and copy_module_binding :
+  Ast_411.Parsetree.module_binding -> Ast_412.Parsetree.module_binding =
+  fun
+    { Ast_411.Parsetree.pmb_name = pmb_name;
+      Ast_411.Parsetree.pmb_expr = pmb_expr;
+      Ast_411.Parsetree.pmb_attributes = pmb_attributes;
+      Ast_411.Parsetree.pmb_loc = pmb_loc }
+    ->
+    {
+      Ast_412.Parsetree.pmb_name =
+        (copy_loc (fun x -> Option.map (fun x -> x) x) pmb_name);
+      Ast_412.Parsetree.pmb_expr = (copy_module_expr pmb_expr);
+      Ast_412.Parsetree.pmb_attributes = (copy_attributes pmb_attributes);
+      Ast_412.Parsetree.pmb_loc = (copy_location pmb_loc)
+    }
+and copy_module_expr :
+  Ast_411.Parsetree.module_expr -> Ast_412.Parsetree.module_expr =
+  fun
+    { Ast_411.Parsetree.pmod_desc = pmod_desc;
+      Ast_411.Parsetree.pmod_loc = pmod_loc;
+      Ast_411.Parsetree.pmod_attributes = pmod_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pmod_desc = (copy_module_expr_desc pmod_desc);
+      Ast_412.Parsetree.pmod_loc = (copy_location pmod_loc);
+      Ast_412.Parsetree.pmod_attributes = (copy_attributes pmod_attributes)
+    }
+and copy_module_expr_desc :
+  Ast_411.Parsetree.module_expr_desc -> Ast_412.Parsetree.module_expr_desc =
+  function
+  | Ast_411.Parsetree.Pmod_ident x0 ->
+      Ast_412.Parsetree.Pmod_ident (copy_loc copy_Longident_t x0)
+  | Ast_411.Parsetree.Pmod_structure x0 ->
+      Ast_412.Parsetree.Pmod_structure (copy_structure x0)
+  | Ast_411.Parsetree.Pmod_functor (x0, x1) ->
+      Ast_412.Parsetree.Pmod_functor
+        ((copy_functor_parameter x0), (copy_module_expr x1))
+  | Ast_411.Parsetree.Pmod_apply (x0, x1) ->
+      Ast_412.Parsetree.Pmod_apply
+        ((copy_module_expr x0), (copy_module_expr x1))
+  | Ast_411.Parsetree.Pmod_constraint (x0, x1) ->
+      Ast_412.Parsetree.Pmod_constraint
+        ((copy_module_expr x0), (copy_module_type x1))
+  | Ast_411.Parsetree.Pmod_unpack x0 ->
+      Ast_412.Parsetree.Pmod_unpack (copy_expression x0)
+  | Ast_411.Parsetree.Pmod_extension x0 ->
+      Ast_412.Parsetree.Pmod_extension (copy_extension x0)
+and copy_functor_parameter :
+  Ast_411.Parsetree.functor_parameter -> Ast_412.Parsetree.functor_parameter
+  =
+  function
+  | Ast_411.Parsetree.Unit -> Ast_412.Parsetree.Unit
+  | Ast_411.Parsetree.Named (x0, x1) ->
+      Ast_412.Parsetree.Named
+        ((copy_loc (fun x -> Option.map (fun x -> x) x) x0),
+          (copy_module_type x1))
+and copy_module_type :
+  Ast_411.Parsetree.module_type -> Ast_412.Parsetree.module_type =
+  fun
+    { Ast_411.Parsetree.pmty_desc = pmty_desc;
+      Ast_411.Parsetree.pmty_loc = pmty_loc;
+      Ast_411.Parsetree.pmty_attributes = pmty_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pmty_desc = (copy_module_type_desc pmty_desc);
+      Ast_412.Parsetree.pmty_loc = (copy_location pmty_loc);
+      Ast_412.Parsetree.pmty_attributes = (copy_attributes pmty_attributes)
+    }
+and copy_module_type_desc :
+  Ast_411.Parsetree.module_type_desc -> Ast_412.Parsetree.module_type_desc =
+  function
+  | Ast_411.Parsetree.Pmty_ident x0 ->
+      Ast_412.Parsetree.Pmty_ident (copy_loc copy_Longident_t x0)
+  | Ast_411.Parsetree.Pmty_signature x0 ->
+      Ast_412.Parsetree.Pmty_signature (copy_signature x0)
+  | Ast_411.Parsetree.Pmty_functor (x0, x1) ->
+      Ast_412.Parsetree.Pmty_functor
+        ((copy_functor_parameter x0), (copy_module_type x1))
+  | Ast_411.Parsetree.Pmty_with (x0, x1) ->
+      Ast_412.Parsetree.Pmty_with
+        ((copy_module_type x0), (List.map copy_with_constraint x1))
+  | Ast_411.Parsetree.Pmty_typeof x0 ->
+      Ast_412.Parsetree.Pmty_typeof (copy_module_expr x0)
+  | Ast_411.Parsetree.Pmty_extension x0 ->
+      Ast_412.Parsetree.Pmty_extension (copy_extension x0)
+  | Ast_411.Parsetree.Pmty_alias x0 ->
+      Ast_412.Parsetree.Pmty_alias (copy_loc copy_Longident_t x0)
+and copy_with_constraint :
+  Ast_411.Parsetree.with_constraint -> Ast_412.Parsetree.with_constraint =
+  function
+  | Ast_411.Parsetree.Pwith_type (x0, x1) ->
+      Ast_412.Parsetree.Pwith_type
+        ((copy_loc copy_Longident_t x0), (copy_type_declaration x1))
+  | Ast_411.Parsetree.Pwith_module (x0, x1) ->
+      Ast_412.Parsetree.Pwith_module
+        ((copy_loc copy_Longident_t x0), (copy_loc copy_Longident_t x1))
+  | Ast_411.Parsetree.Pwith_typesubst (x0, x1) ->
+      Ast_412.Parsetree.Pwith_typesubst
+        ((copy_loc copy_Longident_t x0), (copy_type_declaration x1))
+  | Ast_411.Parsetree.Pwith_modsubst (x0, x1) ->
+      Ast_412.Parsetree.Pwith_modsubst
+        ((copy_loc copy_Longident_t x0), (copy_loc copy_Longident_t x1))
+and copy_signature :
+  Ast_411.Parsetree.signature -> Ast_412.Parsetree.signature =
+  fun x -> List.map copy_signature_item x
+and copy_signature_item :
+  Ast_411.Parsetree.signature_item -> Ast_412.Parsetree.signature_item =
+  fun
+    { Ast_411.Parsetree.psig_desc = psig_desc;
+      Ast_411.Parsetree.psig_loc = psig_loc }
+    ->
+    {
+      Ast_412.Parsetree.psig_desc = (copy_signature_item_desc psig_desc);
+      Ast_412.Parsetree.psig_loc = (copy_location psig_loc)
+    }
+and copy_signature_item_desc :
+  Ast_411.Parsetree.signature_item_desc ->
+    Ast_412.Parsetree.signature_item_desc
+  =
+  function
+  | Ast_411.Parsetree.Psig_value x0 ->
+      Ast_412.Parsetree.Psig_value (copy_value_description x0)
+  | Ast_411.Parsetree.Psig_type (x0, x1) ->
+      Ast_412.Parsetree.Psig_type
+        ((copy_rec_flag x0), (List.map copy_type_declaration x1))
+  | Ast_411.Parsetree.Psig_typesubst x0 ->
+      Ast_412.Parsetree.Psig_typesubst (List.map copy_type_declaration x0)
+  | Ast_411.Parsetree.Psig_typext x0 ->
+      Ast_412.Parsetree.Psig_typext (copy_type_extension x0)
+  | Ast_411.Parsetree.Psig_exception x0 ->
+      Ast_412.Parsetree.Psig_exception (copy_type_exception x0)
+  | Ast_411.Parsetree.Psig_module x0 ->
+      Ast_412.Parsetree.Psig_module (copy_module_declaration x0)
+  | Ast_411.Parsetree.Psig_modsubst x0 ->
+      Ast_412.Parsetree.Psig_modsubst (copy_module_substitution x0)
+  | Ast_411.Parsetree.Psig_recmodule x0 ->
+      Ast_412.Parsetree.Psig_recmodule (List.map copy_module_declaration x0)
+  | Ast_411.Parsetree.Psig_modtype x0 ->
+      Ast_412.Parsetree.Psig_modtype (copy_module_type_declaration x0)
+  | Ast_411.Parsetree.Psig_open x0 ->
+      Ast_412.Parsetree.Psig_open (copy_open_description x0)
+  | Ast_411.Parsetree.Psig_include x0 ->
+      Ast_412.Parsetree.Psig_include (copy_include_description x0)
+  | Ast_411.Parsetree.Psig_class x0 ->
+      Ast_412.Parsetree.Psig_class (List.map copy_class_description x0)
+  | Ast_411.Parsetree.Psig_class_type x0 ->
+      Ast_412.Parsetree.Psig_class_type
+        (List.map copy_class_type_declaration x0)
+  | Ast_411.Parsetree.Psig_attribute x0 ->
+      Ast_412.Parsetree.Psig_attribute (copy_attribute x0)
+  | Ast_411.Parsetree.Psig_extension (x0, x1) ->
+      Ast_412.Parsetree.Psig_extension
+        ((copy_extension x0), (copy_attributes x1))
+and copy_class_type_declaration :
+  Ast_411.Parsetree.class_type_declaration ->
+    Ast_412.Parsetree.class_type_declaration
+  = fun x -> copy_class_infos copy_class_type x
+and copy_class_description :
+  Ast_411.Parsetree.class_description -> Ast_412.Parsetree.class_description
+  = fun x -> copy_class_infos copy_class_type x
+and copy_class_type :
+  Ast_411.Parsetree.class_type -> Ast_412.Parsetree.class_type =
+  fun
+    { Ast_411.Parsetree.pcty_desc = pcty_desc;
+      Ast_411.Parsetree.pcty_loc = pcty_loc;
+      Ast_411.Parsetree.pcty_attributes = pcty_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pcty_desc = (copy_class_type_desc pcty_desc);
+      Ast_412.Parsetree.pcty_loc = (copy_location pcty_loc);
+      Ast_412.Parsetree.pcty_attributes = (copy_attributes pcty_attributes)
+    }
+and copy_class_type_desc :
+  Ast_411.Parsetree.class_type_desc -> Ast_412.Parsetree.class_type_desc =
+  function
+  | Ast_411.Parsetree.Pcty_constr (x0, x1) ->
+      Ast_412.Parsetree.Pcty_constr
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_411.Parsetree.Pcty_signature x0 ->
+      Ast_412.Parsetree.Pcty_signature (copy_class_signature x0)
+  | Ast_411.Parsetree.Pcty_arrow (x0, x1, x2) ->
+      Ast_412.Parsetree.Pcty_arrow
+        ((copy_arg_label x0), (copy_core_type x1), (copy_class_type x2))
+  | Ast_411.Parsetree.Pcty_extension x0 ->
+      Ast_412.Parsetree.Pcty_extension (copy_extension x0)
+  | Ast_411.Parsetree.Pcty_open (x0, x1) ->
+      Ast_412.Parsetree.Pcty_open
+        ((copy_open_description x0), (copy_class_type x1))
+and copy_class_signature :
+  Ast_411.Parsetree.class_signature -> Ast_412.Parsetree.class_signature =
+  fun
+    { Ast_411.Parsetree.pcsig_self = pcsig_self;
+      Ast_411.Parsetree.pcsig_fields = pcsig_fields }
+    ->
+    {
+      Ast_412.Parsetree.pcsig_self = (copy_core_type pcsig_self);
+      Ast_412.Parsetree.pcsig_fields =
+        (List.map copy_class_type_field pcsig_fields)
+    }
+and copy_class_type_field :
+  Ast_411.Parsetree.class_type_field -> Ast_412.Parsetree.class_type_field =
+  fun
+    { Ast_411.Parsetree.pctf_desc = pctf_desc;
+      Ast_411.Parsetree.pctf_loc = pctf_loc;
+      Ast_411.Parsetree.pctf_attributes = pctf_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pctf_desc = (copy_class_type_field_desc pctf_desc);
+      Ast_412.Parsetree.pctf_loc = (copy_location pctf_loc);
+      Ast_412.Parsetree.pctf_attributes = (copy_attributes pctf_attributes)
+    }
+and copy_class_type_field_desc :
+  Ast_411.Parsetree.class_type_field_desc ->
+    Ast_412.Parsetree.class_type_field_desc
+  =
+  function
+  | Ast_411.Parsetree.Pctf_inherit x0 ->
+      Ast_412.Parsetree.Pctf_inherit (copy_class_type x0)
+  | Ast_411.Parsetree.Pctf_val x0 ->
+      Ast_412.Parsetree.Pctf_val
+        (let (x0, x1, x2, x3) = x0 in
+         ((copy_loc copy_label x0), (copy_mutable_flag x1),
+           (copy_virtual_flag x2), (copy_core_type x3)))
+  | Ast_411.Parsetree.Pctf_method x0 ->
+      Ast_412.Parsetree.Pctf_method
+        (let (x0, x1, x2, x3) = x0 in
+         ((copy_loc copy_label x0), (copy_private_flag x1),
+           (copy_virtual_flag x2), (copy_core_type x3)))
+  | Ast_411.Parsetree.Pctf_constraint x0 ->
+      Ast_412.Parsetree.Pctf_constraint
+        (let (x0, x1) = x0 in ((copy_core_type x0), (copy_core_type x1)))
+  | Ast_411.Parsetree.Pctf_attribute x0 ->
+      Ast_412.Parsetree.Pctf_attribute (copy_attribute x0)
+  | Ast_411.Parsetree.Pctf_extension x0 ->
+      Ast_412.Parsetree.Pctf_extension (copy_extension x0)
+and copy_extension :
+  Ast_411.Parsetree.extension -> Ast_412.Parsetree.extension =
+  fun x ->
+    let (x0, x1) = x in ((copy_loc (fun x -> x) x0), (copy_payload x1))
+and copy_class_infos :
+  'f0 'g0 .
+    ('f0 -> 'g0) ->
+      'f0 Ast_411.Parsetree.class_infos -> 'g0 Ast_412.Parsetree.class_infos
+  =
+  fun f0 ->
+    fun
+      { Ast_411.Parsetree.pci_virt = pci_virt;
+        Ast_411.Parsetree.pci_params = pci_params;
+        Ast_411.Parsetree.pci_name = pci_name;
+        Ast_411.Parsetree.pci_expr = pci_expr;
+        Ast_411.Parsetree.pci_loc = pci_loc;
+        Ast_411.Parsetree.pci_attributes = pci_attributes }
+      ->
+      {
+        Ast_412.Parsetree.pci_virt = (copy_virtual_flag pci_virt);
+        Ast_412.Parsetree.pci_params =
+          (List.map
+             (fun x ->
+                let (x0, x1) = x in ((copy_core_type x0), (copy_variance x1)))
+             pci_params);
+        Ast_412.Parsetree.pci_name = (copy_loc (fun x -> x) pci_name);
+        Ast_412.Parsetree.pci_expr = (f0 pci_expr);
+        Ast_412.Parsetree.pci_loc = (copy_location pci_loc);
+        Ast_412.Parsetree.pci_attributes = (copy_attributes pci_attributes)
+      }
+and copy_virtual_flag :
+  Ast_411.Asttypes.virtual_flag -> Ast_412.Asttypes.virtual_flag =
+  function
+  | Ast_411.Asttypes.Virtual -> Ast_412.Asttypes.Virtual
+  | Ast_411.Asttypes.Concrete -> Ast_412.Asttypes.Concrete
+and copy_include_description :
+  Ast_411.Parsetree.include_description ->
+    Ast_412.Parsetree.include_description
+  = fun x -> copy_include_infos copy_module_type x
+and copy_include_infos :
+  'f0 'g0 .
+    ('f0 -> 'g0) ->
+      'f0 Ast_411.Parsetree.include_infos ->
+        'g0 Ast_412.Parsetree.include_infos
+  =
+  fun f0 ->
+    fun
+      { Ast_411.Parsetree.pincl_mod = pincl_mod;
+        Ast_411.Parsetree.pincl_loc = pincl_loc;
+        Ast_411.Parsetree.pincl_attributes = pincl_attributes }
+      ->
+      {
+        Ast_412.Parsetree.pincl_mod = (f0 pincl_mod);
+        Ast_412.Parsetree.pincl_loc = (copy_location pincl_loc);
+        Ast_412.Parsetree.pincl_attributes =
+          (copy_attributes pincl_attributes)
+      }
+and copy_open_description :
+  Ast_411.Parsetree.open_description -> Ast_412.Parsetree.open_description =
+  fun x -> copy_open_infos (fun x -> copy_loc copy_Longident_t x) x
+and copy_open_infos :
+  'f0 'g0 .
+    ('f0 -> 'g0) ->
+      'f0 Ast_411.Parsetree.open_infos -> 'g0 Ast_412.Parsetree.open_infos
+  =
+  fun f0 ->
+    fun
+      { Ast_411.Parsetree.popen_expr = popen_expr;
+        Ast_411.Parsetree.popen_override = popen_override;
+        Ast_411.Parsetree.popen_loc = popen_loc;
+        Ast_411.Parsetree.popen_attributes = popen_attributes }
+      ->
+      {
+        Ast_412.Parsetree.popen_expr = (f0 popen_expr);
+        Ast_412.Parsetree.popen_override =
+          (copy_override_flag popen_override);
+        Ast_412.Parsetree.popen_loc = (copy_location popen_loc);
+        Ast_412.Parsetree.popen_attributes =
+          (copy_attributes popen_attributes)
+      }
+and copy_override_flag :
+  Ast_411.Asttypes.override_flag -> Ast_412.Asttypes.override_flag =
+  function
+  | Ast_411.Asttypes.Override -> Ast_412.Asttypes.Override
+  | Ast_411.Asttypes.Fresh -> Ast_412.Asttypes.Fresh
+and copy_module_type_declaration :
+  Ast_411.Parsetree.module_type_declaration ->
+    Ast_412.Parsetree.module_type_declaration
+  =
+  fun
+    { Ast_411.Parsetree.pmtd_name = pmtd_name;
+      Ast_411.Parsetree.pmtd_type = pmtd_type;
+      Ast_411.Parsetree.pmtd_attributes = pmtd_attributes;
+      Ast_411.Parsetree.pmtd_loc = pmtd_loc }
+    ->
+    {
+      Ast_412.Parsetree.pmtd_name = (copy_loc (fun x -> x) pmtd_name);
+      Ast_412.Parsetree.pmtd_type = (Option.map copy_module_type pmtd_type);
+      Ast_412.Parsetree.pmtd_attributes = (copy_attributes pmtd_attributes);
+      Ast_412.Parsetree.pmtd_loc = (copy_location pmtd_loc)
+    }
+and copy_module_substitution :
+  Ast_411.Parsetree.module_substitution ->
+    Ast_412.Parsetree.module_substitution
+  =
+  fun
+    { Ast_411.Parsetree.pms_name = pms_name;
+      Ast_411.Parsetree.pms_manifest = pms_manifest;
+      Ast_411.Parsetree.pms_attributes = pms_attributes;
+      Ast_411.Parsetree.pms_loc = pms_loc }
+    ->
+    {
+      Ast_412.Parsetree.pms_name = (copy_loc (fun x -> x) pms_name);
+      Ast_412.Parsetree.pms_manifest =
+        (copy_loc copy_Longident_t pms_manifest);
+      Ast_412.Parsetree.pms_attributes = (copy_attributes pms_attributes);
+      Ast_412.Parsetree.pms_loc = (copy_location pms_loc)
+    }
+and copy_module_declaration :
+  Ast_411.Parsetree.module_declaration ->
+    Ast_412.Parsetree.module_declaration
+  =
+  fun
+    { Ast_411.Parsetree.pmd_name = pmd_name;
+      Ast_411.Parsetree.pmd_type = pmd_type;
+      Ast_411.Parsetree.pmd_attributes = pmd_attributes;
+      Ast_411.Parsetree.pmd_loc = pmd_loc }
+    ->
+    {
+      Ast_412.Parsetree.pmd_name =
+        (copy_loc (fun x -> Option.map (fun x -> x) x) pmd_name);
+      Ast_412.Parsetree.pmd_type = (copy_module_type pmd_type);
+      Ast_412.Parsetree.pmd_attributes = (copy_attributes pmd_attributes);
+      Ast_412.Parsetree.pmd_loc = (copy_location pmd_loc)
+    }
+and copy_type_exception :
+  Ast_411.Parsetree.type_exception -> Ast_412.Parsetree.type_exception =
+  fun
+    { Ast_411.Parsetree.ptyexn_constructor = ptyexn_constructor;
+      Ast_411.Parsetree.ptyexn_loc = ptyexn_loc;
+      Ast_411.Parsetree.ptyexn_attributes = ptyexn_attributes }
+    ->
+    {
+      Ast_412.Parsetree.ptyexn_constructor =
+        (copy_extension_constructor ptyexn_constructor);
+      Ast_412.Parsetree.ptyexn_loc = (copy_location ptyexn_loc);
+      Ast_412.Parsetree.ptyexn_attributes =
+        (copy_attributes ptyexn_attributes)
+    }
+and copy_type_extension :
+  Ast_411.Parsetree.type_extension -> Ast_412.Parsetree.type_extension =
+  fun
+    { Ast_411.Parsetree.ptyext_path = ptyext_path;
+      Ast_411.Parsetree.ptyext_params = ptyext_params;
+      Ast_411.Parsetree.ptyext_constructors = ptyext_constructors;
+      Ast_411.Parsetree.ptyext_private = ptyext_private;
+      Ast_411.Parsetree.ptyext_loc = ptyext_loc;
+      Ast_411.Parsetree.ptyext_attributes = ptyext_attributes }
+    ->
+    {
+      Ast_412.Parsetree.ptyext_path = (copy_loc copy_Longident_t ptyext_path);
+      Ast_412.Parsetree.ptyext_params =
+        (List.map
+           (fun x ->
+              let (x0, x1) = x in ((copy_core_type x0), (copy_variance x1)))
+           ptyext_params);
+      Ast_412.Parsetree.ptyext_constructors =
+        (List.map copy_extension_constructor ptyext_constructors);
+      Ast_412.Parsetree.ptyext_private = (copy_private_flag ptyext_private);
+      Ast_412.Parsetree.ptyext_loc = (copy_location ptyext_loc);
+      Ast_412.Parsetree.ptyext_attributes =
+        (copy_attributes ptyext_attributes)
+    }
+and copy_extension_constructor :
+  Ast_411.Parsetree.extension_constructor ->
+    Ast_412.Parsetree.extension_constructor
+  =
+  fun
+    { Ast_411.Parsetree.pext_name = pext_name;
+      Ast_411.Parsetree.pext_kind = pext_kind;
+      Ast_411.Parsetree.pext_loc = pext_loc;
+      Ast_411.Parsetree.pext_attributes = pext_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pext_name = (copy_loc (fun x -> x) pext_name);
+      Ast_412.Parsetree.pext_kind =
+        (copy_extension_constructor_kind pext_kind);
+      Ast_412.Parsetree.pext_loc = (copy_location pext_loc);
+      Ast_412.Parsetree.pext_attributes = (copy_attributes pext_attributes)
+    }
+and copy_extension_constructor_kind :
+  Ast_411.Parsetree.extension_constructor_kind ->
+    Ast_412.Parsetree.extension_constructor_kind
+  =
+  function
+  | Ast_411.Parsetree.Pext_decl (x0, x1) ->
+      Ast_412.Parsetree.Pext_decl
+        ((copy_constructor_arguments x0), (Option.map copy_core_type x1))
+  | Ast_411.Parsetree.Pext_rebind x0 ->
+      Ast_412.Parsetree.Pext_rebind (copy_loc copy_Longident_t x0)
+and copy_type_declaration :
+  Ast_411.Parsetree.type_declaration -> Ast_412.Parsetree.type_declaration =
+  fun
+    { Ast_411.Parsetree.ptype_name = ptype_name;
+      Ast_411.Parsetree.ptype_params = ptype_params;
+      Ast_411.Parsetree.ptype_cstrs = ptype_cstrs;
+      Ast_411.Parsetree.ptype_kind = ptype_kind;
+      Ast_411.Parsetree.ptype_private = ptype_private;
+      Ast_411.Parsetree.ptype_manifest = ptype_manifest;
+      Ast_411.Parsetree.ptype_attributes = ptype_attributes;
+      Ast_411.Parsetree.ptype_loc = ptype_loc }
+    ->
+    {
+      Ast_412.Parsetree.ptype_name = (copy_loc (fun x -> x) ptype_name);
+      Ast_412.Parsetree.ptype_params =
+        (List.map
+           (fun x ->
+              let (x0, x1) = x in ((copy_core_type x0), (copy_variance x1)))
+           ptype_params);
+      Ast_412.Parsetree.ptype_cstrs =
+        (List.map
+           (fun x ->
+              let (x0, x1, x2) = x in
+              ((copy_core_type x0), (copy_core_type x1), (copy_location x2)))
+           ptype_cstrs);
+      Ast_412.Parsetree.ptype_kind = (copy_type_kind ptype_kind);
+      Ast_412.Parsetree.ptype_private = (copy_private_flag ptype_private);
+      Ast_412.Parsetree.ptype_manifest =
+        (Option.map copy_core_type ptype_manifest);
+      Ast_412.Parsetree.ptype_attributes = (copy_attributes ptype_attributes);
+      Ast_412.Parsetree.ptype_loc = (copy_location ptype_loc)
+    }
+and copy_private_flag :
+  Ast_411.Asttypes.private_flag -> Ast_412.Asttypes.private_flag =
+  function
+  | Ast_411.Asttypes.Private -> Ast_412.Asttypes.Private
+  | Ast_411.Asttypes.Public -> Ast_412.Asttypes.Public
+and copy_type_kind :
+  Ast_411.Parsetree.type_kind -> Ast_412.Parsetree.type_kind =
+  function
+  | Ast_411.Parsetree.Ptype_abstract -> Ast_412.Parsetree.Ptype_abstract
+  | Ast_411.Parsetree.Ptype_variant x0 ->
+      Ast_412.Parsetree.Ptype_variant
+        (List.map copy_constructor_declaration x0)
+  | Ast_411.Parsetree.Ptype_record x0 ->
+      Ast_412.Parsetree.Ptype_record (List.map copy_label_declaration x0)
+  | Ast_411.Parsetree.Ptype_open -> Ast_412.Parsetree.Ptype_open
+and copy_constructor_declaration :
+  Ast_411.Parsetree.constructor_declaration ->
+    Ast_412.Parsetree.constructor_declaration
+  =
+  fun
+    { Ast_411.Parsetree.pcd_name = pcd_name;
+      Ast_411.Parsetree.pcd_args = pcd_args;
+      Ast_411.Parsetree.pcd_res = pcd_res;
+      Ast_411.Parsetree.pcd_loc = pcd_loc;
+      Ast_411.Parsetree.pcd_attributes = pcd_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pcd_name = (copy_loc (fun x -> x) pcd_name);
+      Ast_412.Parsetree.pcd_args = (copy_constructor_arguments pcd_args);
+      Ast_412.Parsetree.pcd_res = (Option.map copy_core_type pcd_res);
+      Ast_412.Parsetree.pcd_loc = (copy_location pcd_loc);
+      Ast_412.Parsetree.pcd_attributes = (copy_attributes pcd_attributes)
+    }
+and copy_constructor_arguments :
+  Ast_411.Parsetree.constructor_arguments ->
+    Ast_412.Parsetree.constructor_arguments
+  =
+  function
+  | Ast_411.Parsetree.Pcstr_tuple x0 ->
+      Ast_412.Parsetree.Pcstr_tuple (List.map copy_core_type x0)
+  | Ast_411.Parsetree.Pcstr_record x0 ->
+      Ast_412.Parsetree.Pcstr_record (List.map copy_label_declaration x0)
+and copy_label_declaration :
+  Ast_411.Parsetree.label_declaration -> Ast_412.Parsetree.label_declaration
+  =
+  fun
+    { Ast_411.Parsetree.pld_name = pld_name;
+      Ast_411.Parsetree.pld_mutable = pld_mutable;
+      Ast_411.Parsetree.pld_type = pld_type;
+      Ast_411.Parsetree.pld_loc = pld_loc;
+      Ast_411.Parsetree.pld_attributes = pld_attributes }
+    ->
+    {
+      Ast_412.Parsetree.pld_name = (copy_loc (fun x -> x) pld_name);
+      Ast_412.Parsetree.pld_mutable = (copy_mutable_flag pld_mutable);
+      Ast_412.Parsetree.pld_type = (copy_core_type pld_type);
+      Ast_412.Parsetree.pld_loc = (copy_location pld_loc);
+      Ast_412.Parsetree.pld_attributes = (copy_attributes pld_attributes)
+    }
+and copy_mutable_flag :
+  Ast_411.Asttypes.mutable_flag -> Ast_412.Asttypes.mutable_flag =
+  function
+  | Ast_411.Asttypes.Immutable -> Ast_412.Asttypes.Immutable
+  | Ast_411.Asttypes.Mutable -> Ast_412.Asttypes.Mutable
+and copy_variance : Ast_411.Asttypes.variance -> Ast_412.Asttypes.variance =
+  function
+  | Ast_411.Asttypes.Covariant -> Ast_412.Asttypes.Covariant
+  | Ast_411.Asttypes.Contravariant -> Ast_412.Asttypes.Contravariant
+  | Ast_411.Asttypes.Invariant -> Ast_412.Asttypes.Invariant
+and copy_value_description :
+  Ast_411.Parsetree.value_description -> Ast_412.Parsetree.value_description
+  =
+  fun
+    { Ast_411.Parsetree.pval_name = pval_name;
+      Ast_411.Parsetree.pval_type = pval_type;
+      Ast_411.Parsetree.pval_prim = pval_prim;
+      Ast_411.Parsetree.pval_attributes = pval_attributes;
+      Ast_411.Parsetree.pval_loc = pval_loc }
+    ->
+    {
+      Ast_412.Parsetree.pval_name = (copy_loc (fun x -> x) pval_name);
+      Ast_412.Parsetree.pval_type = (copy_core_type pval_type);
+      Ast_412.Parsetree.pval_prim = (List.map (fun x -> x) pval_prim);
+      Ast_412.Parsetree.pval_attributes = (copy_attributes pval_attributes);
+      Ast_412.Parsetree.pval_loc = (copy_location pval_loc)
+    }
+and copy_object_field_desc :
+  Ast_411.Parsetree.object_field_desc -> Ast_412.Parsetree.object_field_desc
+  =
+  function
+  | Ast_411.Parsetree.Otag (x0, x1) ->
+      Ast_412.Parsetree.Otag ((copy_loc copy_label x0), (copy_core_type x1))
+  | Ast_411.Parsetree.Oinherit x0 ->
+      Ast_412.Parsetree.Oinherit (copy_core_type x0)
+and copy_arg_label : Ast_411.Asttypes.arg_label -> Ast_412.Asttypes.arg_label
+  =
+  function
+  | Ast_411.Asttypes.Nolabel -> Ast_412.Asttypes.Nolabel
+  | Ast_411.Asttypes.Labelled x0 -> Ast_412.Asttypes.Labelled x0
+  | Ast_411.Asttypes.Optional x0 -> Ast_412.Asttypes.Optional x0
+and copy_closed_flag :
+  Ast_411.Asttypes.closed_flag -> Ast_412.Asttypes.closed_flag =
+  function
+  | Ast_411.Asttypes.Closed -> Ast_412.Asttypes.Closed
+  | Ast_411.Asttypes.Open -> Ast_412.Asttypes.Open
+and copy_label : Ast_411.Asttypes.label -> Ast_412.Asttypes.label =
+  fun x -> x
+and copy_rec_flag : Ast_411.Asttypes.rec_flag -> Ast_412.Asttypes.rec_flag =
+  function
+  | Ast_411.Asttypes.Nonrecursive -> Ast_412.Asttypes.Nonrecursive
+  | Ast_411.Asttypes.Recursive -> Ast_412.Asttypes.Recursive
+and copy_constant : Ast_411.Parsetree.constant -> Ast_412.Parsetree.constant
+  =
+  function
+  | Ast_411.Parsetree.Pconst_integer (x0, x1) ->
+      Ast_412.Parsetree.Pconst_integer (x0, (Option.map (fun x -> x) x1))
+  | Ast_411.Parsetree.Pconst_char x0 -> Ast_412.Parsetree.Pconst_char x0
+  | Ast_411.Parsetree.Pconst_string (x0, x1, x2) ->
+      Ast_412.Parsetree.Pconst_string
+        (x0, (copy_location x1), (Option.map (fun x -> x) x2))
+  | Ast_411.Parsetree.Pconst_float (x0, x1) ->
+      Ast_412.Parsetree.Pconst_float (x0, (Option.map (fun x -> x) x1))
+and copy_Longident_t : Longident.t -> Longident.t =
+  function
+  | Longident.Lident x0 -> Longident.Lident x0
+  | Longident.Ldot (x0, x1) -> Longident.Ldot ((copy_Longident_t x0), x1)
+  | Longident.Lapply (x0, x1) ->
+      Longident.Lapply ((copy_Longident_t x0), (copy_Longident_t x1))
+and copy_loc :
+  'f0 'g0 .
+    ('f0 -> 'g0) -> 'f0 Ast_411.Asttypes.loc -> 'g0 Ast_412.Asttypes.loc
+  =
+  fun f0 ->
+    fun { Ast_411.Asttypes.txt = txt; Ast_411.Asttypes.loc = loc } ->
+      {
+        Ast_412.Asttypes.txt = (f0 txt);
+        Ast_412.Asttypes.loc = (copy_location loc)
+      }
+and copy_location : Location.t -> Location.t =
+  fun
+    { Location.loc_start = loc_start; Location.loc_end = loc_end;
+      Location.loc_ghost = loc_ghost }
+    ->
+    {
+      Location.loc_start = (copy_position loc_start);
+      Location.loc_end = (copy_position loc_end);
+      Location.loc_ghost = loc_ghost
+    }
+and copy_position : Stdlib.Lexing.position -> Stdlib.Lexing.position =
+  fun
+    { Stdlib.Lexing.pos_fname = pos_fname; Stdlib.Lexing.pos_lnum = pos_lnum;
+      Stdlib.Lexing.pos_bol = pos_bol; Stdlib.Lexing.pos_cnum = pos_cnum }
+    ->
+    {
+      Stdlib.Lexing.pos_fname = pos_fname;
+      Stdlib.Lexing.pos_lnum = pos_lnum;
+      Stdlib.Lexing.pos_bol = pos_bol;
+      Stdlib.Lexing.pos_cnum = pos_cnum
+    }

--- a/src/migrate_411_412.ml
+++ b/src/migrate_411_412.ml
@@ -312,7 +312,7 @@ and copy_core_type :
     }
 and copy_location_stack :
   Ast_411.Parsetree.location_stack -> Ast_412.Parsetree.location_stack =
-  fun x -> List.map copy_location x
+  fun x -> x
 and copy_core_type_desc :
   Ast_411.Parsetree.core_type_desc -> Ast_412.Parsetree.core_type_desc =
   function
@@ -1166,11 +1166,7 @@ and copy_constant : Ast_411.Parsetree.constant -> Ast_412.Parsetree.constant
   | Ast_411.Parsetree.Pconst_float (x0, x1) ->
       Ast_412.Parsetree.Pconst_float (x0, (Option.map (fun x -> x) x1))
 and copy_Longident_t : Longident.t -> Longident.t =
-  function
-  | Longident.Lident x0 -> Longident.Lident x0
-  | Longident.Ldot (x0, x1) -> Longident.Ldot ((copy_Longident_t x0), x1)
-  | Longident.Lapply (x0, x1) ->
-      Longident.Lapply ((copy_Longident_t x0), (copy_Longident_t x1))
+  fun x -> x
 and copy_loc :
   'f0 'g0 .
     ('f0 -> 'g0) -> 'f0 Ast_411.Asttypes.loc -> 'g0 Ast_412.Asttypes.loc
@@ -1182,23 +1178,6 @@ and copy_loc :
         Ast_412.Asttypes.loc = (copy_location loc)
       }
 and copy_location : Location.t -> Location.t =
-  fun
-    { Location.loc_start = loc_start; Location.loc_end = loc_end;
-      Location.loc_ghost = loc_ghost }
-    ->
-    {
-      Location.loc_start = (copy_position loc_start);
-      Location.loc_end = (copy_position loc_end);
-      Location.loc_ghost = loc_ghost
-    }
+  fun x -> x
 and copy_position : Stdlib.Lexing.position -> Stdlib.Lexing.position =
-  fun
-    { Stdlib.Lexing.pos_fname = pos_fname; Stdlib.Lexing.pos_lnum = pos_lnum;
-      Stdlib.Lexing.pos_bol = pos_bol; Stdlib.Lexing.pos_cnum = pos_cnum }
-    ->
-    {
-      Stdlib.Lexing.pos_fname = pos_fname;
-      Stdlib.Lexing.pos_lnum = pos_lnum;
-      Stdlib.Lexing.pos_bol = pos_bol;
-      Stdlib.Lexing.pos_cnum = pos_cnum
-    }
+  fun x -> x

--- a/src/migrate_412_411.ml
+++ b/src/migrate_412_411.ml
@@ -1,0 +1,1211 @@
+module From = Ast_412
+module To = Ast_411
+let rec copy_toplevel_phrase :
+  Ast_412.Parsetree.toplevel_phrase -> Ast_411.Parsetree.toplevel_phrase =
+  function
+  | Ast_412.Parsetree.Ptop_def x0 ->
+      Ast_411.Parsetree.Ptop_def (copy_structure x0)
+  | Ast_412.Parsetree.Ptop_dir x0 ->
+      Ast_411.Parsetree.Ptop_dir (copy_toplevel_directive x0)
+and copy_toplevel_directive :
+  Ast_412.Parsetree.toplevel_directive ->
+    Ast_411.Parsetree.toplevel_directive
+  =
+  fun
+    { Ast_412.Parsetree.pdir_name = pdir_name;
+      Ast_412.Parsetree.pdir_arg = pdir_arg;
+      Ast_412.Parsetree.pdir_loc = pdir_loc }
+    ->
+    {
+      Ast_411.Parsetree.pdir_name = (copy_loc (fun x -> x) pdir_name);
+      Ast_411.Parsetree.pdir_arg =
+        (Option.map copy_directive_argument pdir_arg);
+      Ast_411.Parsetree.pdir_loc = (copy_location pdir_loc)
+    }
+and copy_directive_argument :
+  Ast_412.Parsetree.directive_argument ->
+    Ast_411.Parsetree.directive_argument
+  =
+  fun
+    { Ast_412.Parsetree.pdira_desc = pdira_desc;
+      Ast_412.Parsetree.pdira_loc = pdira_loc }
+    ->
+    {
+      Ast_411.Parsetree.pdira_desc =
+        (copy_directive_argument_desc pdira_desc);
+      Ast_411.Parsetree.pdira_loc = (copy_location pdira_loc)
+    }
+and copy_directive_argument_desc :
+  Ast_412.Parsetree.directive_argument_desc ->
+    Ast_411.Parsetree.directive_argument_desc
+  =
+  function
+  | Ast_412.Parsetree.Pdir_string x0 -> Ast_411.Parsetree.Pdir_string x0
+  | Ast_412.Parsetree.Pdir_int (x0, x1) ->
+      Ast_411.Parsetree.Pdir_int (x0, (Option.map (fun x -> x) x1))
+  | Ast_412.Parsetree.Pdir_ident x0 ->
+      Ast_411.Parsetree.Pdir_ident (copy_Longident_t x0)
+  | Ast_412.Parsetree.Pdir_bool x0 -> Ast_411.Parsetree.Pdir_bool x0
+and copy_expression :
+  Ast_412.Parsetree.expression -> Ast_411.Parsetree.expression =
+  fun
+    { Ast_412.Parsetree.pexp_desc = pexp_desc;
+      Ast_412.Parsetree.pexp_loc = pexp_loc;
+      Ast_412.Parsetree.pexp_loc_stack = pexp_loc_stack;
+      Ast_412.Parsetree.pexp_attributes = pexp_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pexp_desc = (copy_expression_desc pexp_desc);
+      Ast_411.Parsetree.pexp_loc = (copy_location pexp_loc);
+      Ast_411.Parsetree.pexp_loc_stack = (copy_location_stack pexp_loc_stack);
+      Ast_411.Parsetree.pexp_attributes = (copy_attributes pexp_attributes)
+    }
+and copy_expression_desc :
+  Ast_412.Parsetree.expression_desc -> Ast_411.Parsetree.expression_desc =
+  function
+  | Ast_412.Parsetree.Pexp_ident x0 ->
+      Ast_411.Parsetree.Pexp_ident (copy_loc copy_Longident_t x0)
+  | Ast_412.Parsetree.Pexp_constant x0 ->
+      Ast_411.Parsetree.Pexp_constant (copy_constant x0)
+  | Ast_412.Parsetree.Pexp_let (x0, x1, x2) ->
+      Ast_411.Parsetree.Pexp_let
+        ((copy_rec_flag x0), (List.map copy_value_binding x1),
+          (copy_expression x2))
+  | Ast_412.Parsetree.Pexp_function x0 ->
+      Ast_411.Parsetree.Pexp_function (List.map copy_case x0)
+  | Ast_412.Parsetree.Pexp_fun (x0, x1, x2, x3) ->
+      Ast_411.Parsetree.Pexp_fun
+        ((copy_arg_label x0), (Option.map copy_expression x1),
+          (copy_pattern x2), (copy_expression x3))
+  | Ast_412.Parsetree.Pexp_apply (x0, x1) ->
+      Ast_411.Parsetree.Pexp_apply
+        ((copy_expression x0),
+          (List.map
+             (fun x ->
+                let (x0, x1) = x in
+                ((copy_arg_label x0), (copy_expression x1))) x1))
+  | Ast_412.Parsetree.Pexp_match (x0, x1) ->
+      Ast_411.Parsetree.Pexp_match
+        ((copy_expression x0), (List.map copy_case x1))
+  | Ast_412.Parsetree.Pexp_try (x0, x1) ->
+      Ast_411.Parsetree.Pexp_try
+        ((copy_expression x0), (List.map copy_case x1))
+  | Ast_412.Parsetree.Pexp_tuple x0 ->
+      Ast_411.Parsetree.Pexp_tuple (List.map copy_expression x0)
+  | Ast_412.Parsetree.Pexp_construct (x0, x1) ->
+      Ast_411.Parsetree.Pexp_construct
+        ((copy_loc copy_Longident_t x0), (Option.map copy_expression x1))
+  | Ast_412.Parsetree.Pexp_variant (x0, x1) ->
+      Ast_411.Parsetree.Pexp_variant
+        ((copy_label x0), (Option.map copy_expression x1))
+  | Ast_412.Parsetree.Pexp_record (x0, x1) ->
+      Ast_411.Parsetree.Pexp_record
+        ((List.map
+            (fun x ->
+               let (x0, x1) = x in
+               ((copy_loc copy_Longident_t x0), (copy_expression x1))) x0),
+          (Option.map copy_expression x1))
+  | Ast_412.Parsetree.Pexp_field (x0, x1) ->
+      Ast_411.Parsetree.Pexp_field
+        ((copy_expression x0), (copy_loc copy_Longident_t x1))
+  | Ast_412.Parsetree.Pexp_setfield (x0, x1, x2) ->
+      Ast_411.Parsetree.Pexp_setfield
+        ((copy_expression x0), (copy_loc copy_Longident_t x1),
+          (copy_expression x2))
+  | Ast_412.Parsetree.Pexp_array x0 ->
+      Ast_411.Parsetree.Pexp_array (List.map copy_expression x0)
+  | Ast_412.Parsetree.Pexp_ifthenelse (x0, x1, x2) ->
+      Ast_411.Parsetree.Pexp_ifthenelse
+        ((copy_expression x0), (copy_expression x1),
+          (Option.map copy_expression x2))
+  | Ast_412.Parsetree.Pexp_sequence (x0, x1) ->
+      Ast_411.Parsetree.Pexp_sequence
+        ((copy_expression x0), (copy_expression x1))
+  | Ast_412.Parsetree.Pexp_while (x0, x1) ->
+      Ast_411.Parsetree.Pexp_while
+        ((copy_expression x0), (copy_expression x1))
+  | Ast_412.Parsetree.Pexp_for (x0, x1, x2, x3, x4) ->
+      Ast_411.Parsetree.Pexp_for
+        ((copy_pattern x0), (copy_expression x1), (copy_expression x2),
+          (copy_direction_flag x3), (copy_expression x4))
+  | Ast_412.Parsetree.Pexp_constraint (x0, x1) ->
+      Ast_411.Parsetree.Pexp_constraint
+        ((copy_expression x0), (copy_core_type x1))
+  | Ast_412.Parsetree.Pexp_coerce (x0, x1, x2) ->
+      Ast_411.Parsetree.Pexp_coerce
+        ((copy_expression x0), (Option.map copy_core_type x1),
+          (copy_core_type x2))
+  | Ast_412.Parsetree.Pexp_send (x0, x1) ->
+      Ast_411.Parsetree.Pexp_send
+        ((copy_expression x0), (copy_loc copy_label x1))
+  | Ast_412.Parsetree.Pexp_new x0 ->
+      Ast_411.Parsetree.Pexp_new (copy_loc copy_Longident_t x0)
+  | Ast_412.Parsetree.Pexp_setinstvar (x0, x1) ->
+      Ast_411.Parsetree.Pexp_setinstvar
+        ((copy_loc copy_label x0), (copy_expression x1))
+  | Ast_412.Parsetree.Pexp_override x0 ->
+      Ast_411.Parsetree.Pexp_override
+        (List.map
+           (fun x ->
+              let (x0, x1) = x in
+              ((copy_loc copy_label x0), (copy_expression x1))) x0)
+  | Ast_412.Parsetree.Pexp_letmodule (x0, x1, x2) ->
+      Ast_411.Parsetree.Pexp_letmodule
+        ((copy_loc (fun x -> Option.map (fun x -> x) x) x0),
+          (copy_module_expr x1), (copy_expression x2))
+  | Ast_412.Parsetree.Pexp_letexception (x0, x1) ->
+      Ast_411.Parsetree.Pexp_letexception
+        ((copy_extension_constructor x0), (copy_expression x1))
+  | Ast_412.Parsetree.Pexp_assert x0 ->
+      Ast_411.Parsetree.Pexp_assert (copy_expression x0)
+  | Ast_412.Parsetree.Pexp_lazy x0 ->
+      Ast_411.Parsetree.Pexp_lazy (copy_expression x0)
+  | Ast_412.Parsetree.Pexp_poly (x0, x1) ->
+      Ast_411.Parsetree.Pexp_poly
+        ((copy_expression x0), (Option.map copy_core_type x1))
+  | Ast_412.Parsetree.Pexp_object x0 ->
+      Ast_411.Parsetree.Pexp_object (copy_class_structure x0)
+  | Ast_412.Parsetree.Pexp_newtype (x0, x1) ->
+      Ast_411.Parsetree.Pexp_newtype
+        ((copy_loc (fun x -> x) x0), (copy_expression x1))
+  | Ast_412.Parsetree.Pexp_pack x0 ->
+      Ast_411.Parsetree.Pexp_pack (copy_module_expr x0)
+  | Ast_412.Parsetree.Pexp_open (x0, x1) ->
+      Ast_411.Parsetree.Pexp_open
+        ((copy_open_declaration x0), (copy_expression x1))
+  | Ast_412.Parsetree.Pexp_letop x0 ->
+      Ast_411.Parsetree.Pexp_letop (copy_letop x0)
+  | Ast_412.Parsetree.Pexp_extension x0 ->
+      Ast_411.Parsetree.Pexp_extension (copy_extension x0)
+  | Ast_412.Parsetree.Pexp_unreachable -> Ast_411.Parsetree.Pexp_unreachable
+and copy_letop : Ast_412.Parsetree.letop -> Ast_411.Parsetree.letop =
+  fun
+    { Ast_412.Parsetree.let_ = let_; Ast_412.Parsetree.ands = ands;
+      Ast_412.Parsetree.body = body }
+    ->
+    {
+      Ast_411.Parsetree.let_ = (copy_binding_op let_);
+      Ast_411.Parsetree.ands = (List.map copy_binding_op ands);
+      Ast_411.Parsetree.body = (copy_expression body)
+    }
+and copy_binding_op :
+  Ast_412.Parsetree.binding_op -> Ast_411.Parsetree.binding_op =
+  fun
+    { Ast_412.Parsetree.pbop_op = pbop_op;
+      Ast_412.Parsetree.pbop_pat = pbop_pat;
+      Ast_412.Parsetree.pbop_exp = pbop_exp;
+      Ast_412.Parsetree.pbop_loc = pbop_loc }
+    ->
+    {
+      Ast_411.Parsetree.pbop_op = (copy_loc (fun x -> x) pbop_op);
+      Ast_411.Parsetree.pbop_pat = (copy_pattern pbop_pat);
+      Ast_411.Parsetree.pbop_exp = (copy_expression pbop_exp);
+      Ast_411.Parsetree.pbop_loc = (copy_location pbop_loc)
+    }
+and copy_direction_flag :
+  Ast_412.Asttypes.direction_flag -> Ast_411.Asttypes.direction_flag =
+  function
+  | Ast_412.Asttypes.Upto -> Ast_411.Asttypes.Upto
+  | Ast_412.Asttypes.Downto -> Ast_411.Asttypes.Downto
+and copy_case : Ast_412.Parsetree.case -> Ast_411.Parsetree.case =
+  fun
+    { Ast_412.Parsetree.pc_lhs = pc_lhs;
+      Ast_412.Parsetree.pc_guard = pc_guard;
+      Ast_412.Parsetree.pc_rhs = pc_rhs }
+    ->
+    {
+      Ast_411.Parsetree.pc_lhs = (copy_pattern pc_lhs);
+      Ast_411.Parsetree.pc_guard = (Option.map copy_expression pc_guard);
+      Ast_411.Parsetree.pc_rhs = (copy_expression pc_rhs)
+    }
+and copy_value_binding :
+  Ast_412.Parsetree.value_binding -> Ast_411.Parsetree.value_binding =
+  fun
+    { Ast_412.Parsetree.pvb_pat = pvb_pat;
+      Ast_412.Parsetree.pvb_expr = pvb_expr;
+      Ast_412.Parsetree.pvb_attributes = pvb_attributes;
+      Ast_412.Parsetree.pvb_loc = pvb_loc }
+    ->
+    {
+      Ast_411.Parsetree.pvb_pat = (copy_pattern pvb_pat);
+      Ast_411.Parsetree.pvb_expr = (copy_expression pvb_expr);
+      Ast_411.Parsetree.pvb_attributes = (copy_attributes pvb_attributes);
+      Ast_411.Parsetree.pvb_loc = (copy_location pvb_loc)
+    }
+and copy_pattern : Ast_412.Parsetree.pattern -> Ast_411.Parsetree.pattern =
+  fun
+    { Ast_412.Parsetree.ppat_desc = ppat_desc;
+      Ast_412.Parsetree.ppat_loc = ppat_loc;
+      Ast_412.Parsetree.ppat_loc_stack = ppat_loc_stack;
+      Ast_412.Parsetree.ppat_attributes = ppat_attributes }
+    ->
+    {
+      Ast_411.Parsetree.ppat_desc = (copy_pattern_desc ppat_desc);
+      Ast_411.Parsetree.ppat_loc = (copy_location ppat_loc);
+      Ast_411.Parsetree.ppat_loc_stack = (copy_location_stack ppat_loc_stack);
+      Ast_411.Parsetree.ppat_attributes = (copy_attributes ppat_attributes)
+    }
+and copy_pattern_desc :
+  Ast_412.Parsetree.pattern_desc -> Ast_411.Parsetree.pattern_desc =
+  function
+  | Ast_412.Parsetree.Ppat_any -> Ast_411.Parsetree.Ppat_any
+  | Ast_412.Parsetree.Ppat_var x0 ->
+      Ast_411.Parsetree.Ppat_var (copy_loc (fun x -> x) x0)
+  | Ast_412.Parsetree.Ppat_alias (x0, x1) ->
+      Ast_411.Parsetree.Ppat_alias
+        ((copy_pattern x0), (copy_loc (fun x -> x) x1))
+  | Ast_412.Parsetree.Ppat_constant x0 ->
+      Ast_411.Parsetree.Ppat_constant (copy_constant x0)
+  | Ast_412.Parsetree.Ppat_interval (x0, x1) ->
+      Ast_411.Parsetree.Ppat_interval
+        ((copy_constant x0), (copy_constant x1))
+  | Ast_412.Parsetree.Ppat_tuple x0 ->
+      Ast_411.Parsetree.Ppat_tuple (List.map copy_pattern x0)
+  | Ast_412.Parsetree.Ppat_construct (x0, x1) ->
+      Ast_411.Parsetree.Ppat_construct
+        ((copy_loc copy_Longident_t x0), (Option.map copy_pattern x1))
+  | Ast_412.Parsetree.Ppat_variant (x0, x1) ->
+      Ast_411.Parsetree.Ppat_variant
+        ((copy_label x0), (Option.map copy_pattern x1))
+  | Ast_412.Parsetree.Ppat_record (x0, x1) ->
+      Ast_411.Parsetree.Ppat_record
+        ((List.map
+            (fun x ->
+               let (x0, x1) = x in
+               ((copy_loc copy_Longident_t x0), (copy_pattern x1))) x0),
+          (copy_closed_flag x1))
+  | Ast_412.Parsetree.Ppat_array x0 ->
+      Ast_411.Parsetree.Ppat_array (List.map copy_pattern x0)
+  | Ast_412.Parsetree.Ppat_or (x0, x1) ->
+      Ast_411.Parsetree.Ppat_or ((copy_pattern x0), (copy_pattern x1))
+  | Ast_412.Parsetree.Ppat_constraint (x0, x1) ->
+      Ast_411.Parsetree.Ppat_constraint
+        ((copy_pattern x0), (copy_core_type x1))
+  | Ast_412.Parsetree.Ppat_type x0 ->
+      Ast_411.Parsetree.Ppat_type (copy_loc copy_Longident_t x0)
+  | Ast_412.Parsetree.Ppat_lazy x0 ->
+      Ast_411.Parsetree.Ppat_lazy (copy_pattern x0)
+  | Ast_412.Parsetree.Ppat_unpack x0 ->
+      Ast_411.Parsetree.Ppat_unpack
+        (copy_loc (fun x -> Option.map (fun x -> x) x) x0)
+  | Ast_412.Parsetree.Ppat_exception x0 ->
+      Ast_411.Parsetree.Ppat_exception (copy_pattern x0)
+  | Ast_412.Parsetree.Ppat_extension x0 ->
+      Ast_411.Parsetree.Ppat_extension (copy_extension x0)
+  | Ast_412.Parsetree.Ppat_open (x0, x1) ->
+      Ast_411.Parsetree.Ppat_open
+        ((copy_loc copy_Longident_t x0), (copy_pattern x1))
+and copy_core_type :
+  Ast_412.Parsetree.core_type -> Ast_411.Parsetree.core_type =
+  fun
+    { Ast_412.Parsetree.ptyp_desc = ptyp_desc;
+      Ast_412.Parsetree.ptyp_loc = ptyp_loc;
+      Ast_412.Parsetree.ptyp_loc_stack = ptyp_loc_stack;
+      Ast_412.Parsetree.ptyp_attributes = ptyp_attributes }
+    ->
+    {
+      Ast_411.Parsetree.ptyp_desc = (copy_core_type_desc ptyp_desc);
+      Ast_411.Parsetree.ptyp_loc = (copy_location ptyp_loc);
+      Ast_411.Parsetree.ptyp_loc_stack = (copy_location_stack ptyp_loc_stack);
+      Ast_411.Parsetree.ptyp_attributes = (copy_attributes ptyp_attributes)
+    }
+and copy_location_stack :
+  Ast_412.Parsetree.location_stack -> Ast_411.Parsetree.location_stack =
+  fun x -> List.map copy_location x
+and copy_core_type_desc :
+  Ast_412.Parsetree.core_type_desc -> Ast_411.Parsetree.core_type_desc =
+  function
+  | Ast_412.Parsetree.Ptyp_any -> Ast_411.Parsetree.Ptyp_any
+  | Ast_412.Parsetree.Ptyp_var x0 -> Ast_411.Parsetree.Ptyp_var x0
+  | Ast_412.Parsetree.Ptyp_arrow (x0, x1, x2) ->
+      Ast_411.Parsetree.Ptyp_arrow
+        ((copy_arg_label x0), (copy_core_type x1), (copy_core_type x2))
+  | Ast_412.Parsetree.Ptyp_tuple x0 ->
+      Ast_411.Parsetree.Ptyp_tuple (List.map copy_core_type x0)
+  | Ast_412.Parsetree.Ptyp_constr (x0, x1) ->
+      Ast_411.Parsetree.Ptyp_constr
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_412.Parsetree.Ptyp_object (x0, x1) ->
+      Ast_411.Parsetree.Ptyp_object
+        ((List.map copy_object_field x0), (copy_closed_flag x1))
+  | Ast_412.Parsetree.Ptyp_class (x0, x1) ->
+      Ast_411.Parsetree.Ptyp_class
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_412.Parsetree.Ptyp_alias (x0, x1) ->
+      Ast_411.Parsetree.Ptyp_alias ((copy_core_type x0), x1)
+  | Ast_412.Parsetree.Ptyp_variant (x0, x1, x2) ->
+      Ast_411.Parsetree.Ptyp_variant
+        ((List.map copy_row_field x0), (copy_closed_flag x1),
+          (Option.map (fun x -> List.map copy_label x) x2))
+  | Ast_412.Parsetree.Ptyp_poly (x0, x1) ->
+      Ast_411.Parsetree.Ptyp_poly
+        ((List.map (fun x -> copy_loc (fun x -> x) x) x0),
+          (copy_core_type x1))
+  | Ast_412.Parsetree.Ptyp_package x0 ->
+      Ast_411.Parsetree.Ptyp_package (copy_package_type x0)
+  | Ast_412.Parsetree.Ptyp_extension x0 ->
+      Ast_411.Parsetree.Ptyp_extension (copy_extension x0)
+and copy_package_type :
+  Ast_412.Parsetree.package_type -> Ast_411.Parsetree.package_type =
+  fun x ->
+    let (x0, x1) = x in
+    ((copy_loc copy_Longident_t x0),
+      (List.map
+         (fun x ->
+            let (x0, x1) = x in
+            ((copy_loc copy_Longident_t x0), (copy_core_type x1))) x1))
+and copy_row_field :
+  Ast_412.Parsetree.row_field -> Ast_411.Parsetree.row_field =
+  fun
+    { Ast_412.Parsetree.prf_desc = prf_desc;
+      Ast_412.Parsetree.prf_loc = prf_loc;
+      Ast_412.Parsetree.prf_attributes = prf_attributes }
+    ->
+    {
+      Ast_411.Parsetree.prf_desc = (copy_row_field_desc prf_desc);
+      Ast_411.Parsetree.prf_loc = (copy_location prf_loc);
+      Ast_411.Parsetree.prf_attributes = (copy_attributes prf_attributes)
+    }
+and copy_row_field_desc :
+  Ast_412.Parsetree.row_field_desc -> Ast_411.Parsetree.row_field_desc =
+  function
+  | Ast_412.Parsetree.Rtag (x0, x1, x2) ->
+      Ast_411.Parsetree.Rtag
+        ((copy_loc copy_label x0), x1, (List.map copy_core_type x2))
+  | Ast_412.Parsetree.Rinherit x0 ->
+      Ast_411.Parsetree.Rinherit (copy_core_type x0)
+and copy_object_field :
+  Ast_412.Parsetree.object_field -> Ast_411.Parsetree.object_field =
+  fun
+    { Ast_412.Parsetree.pof_desc = pof_desc;
+      Ast_412.Parsetree.pof_loc = pof_loc;
+      Ast_412.Parsetree.pof_attributes = pof_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pof_desc = (copy_object_field_desc pof_desc);
+      Ast_411.Parsetree.pof_loc = (copy_location pof_loc);
+      Ast_411.Parsetree.pof_attributes = (copy_attributes pof_attributes)
+    }
+and copy_attributes :
+  Ast_412.Parsetree.attributes -> Ast_411.Parsetree.attributes =
+  fun x -> List.map copy_attribute x
+and copy_attribute :
+  Ast_412.Parsetree.attribute -> Ast_411.Parsetree.attribute =
+  fun
+    { Ast_412.Parsetree.attr_name = attr_name;
+      Ast_412.Parsetree.attr_payload = attr_payload;
+      Ast_412.Parsetree.attr_loc = attr_loc }
+    ->
+    {
+      Ast_411.Parsetree.attr_name = (copy_loc (fun x -> x) attr_name);
+      Ast_411.Parsetree.attr_payload = (copy_payload attr_payload);
+      Ast_411.Parsetree.attr_loc = (copy_location attr_loc)
+    }
+and copy_payload : Ast_412.Parsetree.payload -> Ast_411.Parsetree.payload =
+  function
+  | Ast_412.Parsetree.PStr x0 -> Ast_411.Parsetree.PStr (copy_structure x0)
+  | Ast_412.Parsetree.PSig x0 -> Ast_411.Parsetree.PSig (copy_signature x0)
+  | Ast_412.Parsetree.PTyp x0 -> Ast_411.Parsetree.PTyp (copy_core_type x0)
+  | Ast_412.Parsetree.PPat (x0, x1) ->
+      Ast_411.Parsetree.PPat
+        ((copy_pattern x0), (Option.map copy_expression x1))
+and copy_structure :
+  Ast_412.Parsetree.structure -> Ast_411.Parsetree.structure =
+  fun x -> List.map copy_structure_item x
+and copy_structure_item :
+  Ast_412.Parsetree.structure_item -> Ast_411.Parsetree.structure_item =
+  fun
+    { Ast_412.Parsetree.pstr_desc = pstr_desc;
+      Ast_412.Parsetree.pstr_loc = pstr_loc }
+    ->
+    {
+      Ast_411.Parsetree.pstr_desc = (copy_structure_item_desc pstr_desc);
+      Ast_411.Parsetree.pstr_loc = (copy_location pstr_loc)
+    }
+and copy_structure_item_desc :
+  Ast_412.Parsetree.structure_item_desc ->
+    Ast_411.Parsetree.structure_item_desc
+  =
+  function
+  | Ast_412.Parsetree.Pstr_eval (x0, x1) ->
+      Ast_411.Parsetree.Pstr_eval
+        ((copy_expression x0), (copy_attributes x1))
+  | Ast_412.Parsetree.Pstr_value (x0, x1) ->
+      Ast_411.Parsetree.Pstr_value
+        ((copy_rec_flag x0), (List.map copy_value_binding x1))
+  | Ast_412.Parsetree.Pstr_primitive x0 ->
+      Ast_411.Parsetree.Pstr_primitive (copy_value_description x0)
+  | Ast_412.Parsetree.Pstr_type (x0, x1) ->
+      Ast_411.Parsetree.Pstr_type
+        ((copy_rec_flag x0), (List.map copy_type_declaration x1))
+  | Ast_412.Parsetree.Pstr_typext x0 ->
+      Ast_411.Parsetree.Pstr_typext (copy_type_extension x0)
+  | Ast_412.Parsetree.Pstr_exception x0 ->
+      Ast_411.Parsetree.Pstr_exception (copy_type_exception x0)
+  | Ast_412.Parsetree.Pstr_module x0 ->
+      Ast_411.Parsetree.Pstr_module (copy_module_binding x0)
+  | Ast_412.Parsetree.Pstr_recmodule x0 ->
+      Ast_411.Parsetree.Pstr_recmodule (List.map copy_module_binding x0)
+  | Ast_412.Parsetree.Pstr_modtype x0 ->
+      Ast_411.Parsetree.Pstr_modtype (copy_module_type_declaration x0)
+  | Ast_412.Parsetree.Pstr_open x0 ->
+      Ast_411.Parsetree.Pstr_open (copy_open_declaration x0)
+  | Ast_412.Parsetree.Pstr_class x0 ->
+      Ast_411.Parsetree.Pstr_class (List.map copy_class_declaration x0)
+  | Ast_412.Parsetree.Pstr_class_type x0 ->
+      Ast_411.Parsetree.Pstr_class_type
+        (List.map copy_class_type_declaration x0)
+  | Ast_412.Parsetree.Pstr_include x0 ->
+      Ast_411.Parsetree.Pstr_include (copy_include_declaration x0)
+  | Ast_412.Parsetree.Pstr_attribute x0 ->
+      Ast_411.Parsetree.Pstr_attribute (copy_attribute x0)
+  | Ast_412.Parsetree.Pstr_extension (x0, x1) ->
+      Ast_411.Parsetree.Pstr_extension
+        ((copy_extension x0), (copy_attributes x1))
+and copy_include_declaration :
+  Ast_412.Parsetree.include_declaration ->
+    Ast_411.Parsetree.include_declaration
+  = fun x -> copy_include_infos copy_module_expr x
+and copy_class_declaration :
+  Ast_412.Parsetree.class_declaration -> Ast_411.Parsetree.class_declaration
+  = fun x -> copy_class_infos copy_class_expr x
+and copy_class_expr :
+  Ast_412.Parsetree.class_expr -> Ast_411.Parsetree.class_expr =
+  fun
+    { Ast_412.Parsetree.pcl_desc = pcl_desc;
+      Ast_412.Parsetree.pcl_loc = pcl_loc;
+      Ast_412.Parsetree.pcl_attributes = pcl_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pcl_desc = (copy_class_expr_desc pcl_desc);
+      Ast_411.Parsetree.pcl_loc = (copy_location pcl_loc);
+      Ast_411.Parsetree.pcl_attributes = (copy_attributes pcl_attributes)
+    }
+and copy_class_expr_desc :
+  Ast_412.Parsetree.class_expr_desc -> Ast_411.Parsetree.class_expr_desc =
+  function
+  | Ast_412.Parsetree.Pcl_constr (x0, x1) ->
+      Ast_411.Parsetree.Pcl_constr
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_412.Parsetree.Pcl_structure x0 ->
+      Ast_411.Parsetree.Pcl_structure (copy_class_structure x0)
+  | Ast_412.Parsetree.Pcl_fun (x0, x1, x2, x3) ->
+      Ast_411.Parsetree.Pcl_fun
+        ((copy_arg_label x0), (Option.map copy_expression x1),
+          (copy_pattern x2), (copy_class_expr x3))
+  | Ast_412.Parsetree.Pcl_apply (x0, x1) ->
+      Ast_411.Parsetree.Pcl_apply
+        ((copy_class_expr x0),
+          (List.map
+             (fun x ->
+                let (x0, x1) = x in
+                ((copy_arg_label x0), (copy_expression x1))) x1))
+  | Ast_412.Parsetree.Pcl_let (x0, x1, x2) ->
+      Ast_411.Parsetree.Pcl_let
+        ((copy_rec_flag x0), (List.map copy_value_binding x1),
+          (copy_class_expr x2))
+  | Ast_412.Parsetree.Pcl_constraint (x0, x1) ->
+      Ast_411.Parsetree.Pcl_constraint
+        ((copy_class_expr x0), (copy_class_type x1))
+  | Ast_412.Parsetree.Pcl_extension x0 ->
+      Ast_411.Parsetree.Pcl_extension (copy_extension x0)
+  | Ast_412.Parsetree.Pcl_open (x0, x1) ->
+      Ast_411.Parsetree.Pcl_open
+        ((copy_open_description x0), (copy_class_expr x1))
+and copy_class_structure :
+  Ast_412.Parsetree.class_structure -> Ast_411.Parsetree.class_structure =
+  fun
+    { Ast_412.Parsetree.pcstr_self = pcstr_self;
+      Ast_412.Parsetree.pcstr_fields = pcstr_fields }
+    ->
+    {
+      Ast_411.Parsetree.pcstr_self = (copy_pattern pcstr_self);
+      Ast_411.Parsetree.pcstr_fields =
+        (List.map copy_class_field pcstr_fields)
+    }
+and copy_class_field :
+  Ast_412.Parsetree.class_field -> Ast_411.Parsetree.class_field =
+  fun
+    { Ast_412.Parsetree.pcf_desc = pcf_desc;
+      Ast_412.Parsetree.pcf_loc = pcf_loc;
+      Ast_412.Parsetree.pcf_attributes = pcf_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pcf_desc = (copy_class_field_desc pcf_desc);
+      Ast_411.Parsetree.pcf_loc = (copy_location pcf_loc);
+      Ast_411.Parsetree.pcf_attributes = (copy_attributes pcf_attributes)
+    }
+and copy_class_field_desc :
+  Ast_412.Parsetree.class_field_desc -> Ast_411.Parsetree.class_field_desc =
+  function
+  | Ast_412.Parsetree.Pcf_inherit (x0, x1, x2) ->
+      Ast_411.Parsetree.Pcf_inherit
+        ((copy_override_flag x0), (copy_class_expr x1),
+          (Option.map (fun x -> copy_loc (fun x -> x) x) x2))
+  | Ast_412.Parsetree.Pcf_val x0 ->
+      Ast_411.Parsetree.Pcf_val
+        (let (x0, x1, x2) = x0 in
+         ((copy_loc copy_label x0), (copy_mutable_flag x1),
+           (copy_class_field_kind x2)))
+  | Ast_412.Parsetree.Pcf_method x0 ->
+      Ast_411.Parsetree.Pcf_method
+        (let (x0, x1, x2) = x0 in
+         ((copy_loc copy_label x0), (copy_private_flag x1),
+           (copy_class_field_kind x2)))
+  | Ast_412.Parsetree.Pcf_constraint x0 ->
+      Ast_411.Parsetree.Pcf_constraint
+        (let (x0, x1) = x0 in ((copy_core_type x0), (copy_core_type x1)))
+  | Ast_412.Parsetree.Pcf_initializer x0 ->
+      Ast_411.Parsetree.Pcf_initializer (copy_expression x0)
+  | Ast_412.Parsetree.Pcf_attribute x0 ->
+      Ast_411.Parsetree.Pcf_attribute (copy_attribute x0)
+  | Ast_412.Parsetree.Pcf_extension x0 ->
+      Ast_411.Parsetree.Pcf_extension (copy_extension x0)
+and copy_class_field_kind :
+  Ast_412.Parsetree.class_field_kind -> Ast_411.Parsetree.class_field_kind =
+  function
+  | Ast_412.Parsetree.Cfk_virtual x0 ->
+      Ast_411.Parsetree.Cfk_virtual (copy_core_type x0)
+  | Ast_412.Parsetree.Cfk_concrete (x0, x1) ->
+      Ast_411.Parsetree.Cfk_concrete
+        ((copy_override_flag x0), (copy_expression x1))
+and copy_open_declaration :
+  Ast_412.Parsetree.open_declaration -> Ast_411.Parsetree.open_declaration =
+  fun x -> copy_open_infos copy_module_expr x
+and copy_module_binding :
+  Ast_412.Parsetree.module_binding -> Ast_411.Parsetree.module_binding =
+  fun
+    { Ast_412.Parsetree.pmb_name = pmb_name;
+      Ast_412.Parsetree.pmb_expr = pmb_expr;
+      Ast_412.Parsetree.pmb_attributes = pmb_attributes;
+      Ast_412.Parsetree.pmb_loc = pmb_loc }
+    ->
+    {
+      Ast_411.Parsetree.pmb_name =
+        (copy_loc (fun x -> Option.map (fun x -> x) x) pmb_name);
+      Ast_411.Parsetree.pmb_expr = (copy_module_expr pmb_expr);
+      Ast_411.Parsetree.pmb_attributes = (copy_attributes pmb_attributes);
+      Ast_411.Parsetree.pmb_loc = (copy_location pmb_loc)
+    }
+and copy_module_expr :
+  Ast_412.Parsetree.module_expr -> Ast_411.Parsetree.module_expr =
+  fun
+    { Ast_412.Parsetree.pmod_desc = pmod_desc;
+      Ast_412.Parsetree.pmod_loc = pmod_loc;
+      Ast_412.Parsetree.pmod_attributes = pmod_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pmod_desc = (copy_module_expr_desc pmod_desc);
+      Ast_411.Parsetree.pmod_loc = (copy_location pmod_loc);
+      Ast_411.Parsetree.pmod_attributes = (copy_attributes pmod_attributes)
+    }
+and copy_module_expr_desc :
+  Ast_412.Parsetree.module_expr_desc -> Ast_411.Parsetree.module_expr_desc =
+  function
+  | Ast_412.Parsetree.Pmod_ident x0 ->
+      Ast_411.Parsetree.Pmod_ident (copy_loc copy_Longident_t x0)
+  | Ast_412.Parsetree.Pmod_structure x0 ->
+      Ast_411.Parsetree.Pmod_structure (copy_structure x0)
+  | Ast_412.Parsetree.Pmod_functor (x0, x1) ->
+      Ast_411.Parsetree.Pmod_functor
+        ((copy_functor_parameter x0), (copy_module_expr x1))
+  | Ast_412.Parsetree.Pmod_apply (x0, x1) ->
+      Ast_411.Parsetree.Pmod_apply
+        ((copy_module_expr x0), (copy_module_expr x1))
+  | Ast_412.Parsetree.Pmod_constraint (x0, x1) ->
+      Ast_411.Parsetree.Pmod_constraint
+        ((copy_module_expr x0), (copy_module_type x1))
+  | Ast_412.Parsetree.Pmod_unpack x0 ->
+      Ast_411.Parsetree.Pmod_unpack (copy_expression x0)
+  | Ast_412.Parsetree.Pmod_extension x0 ->
+      Ast_411.Parsetree.Pmod_extension (copy_extension x0)
+and copy_functor_parameter :
+  Ast_412.Parsetree.functor_parameter -> Ast_411.Parsetree.functor_parameter
+  =
+  function
+  | Ast_412.Parsetree.Unit -> Ast_411.Parsetree.Unit
+  | Ast_412.Parsetree.Named (x0, x1) ->
+      Ast_411.Parsetree.Named
+        ((copy_loc (fun x -> Option.map (fun x -> x) x) x0),
+          (copy_module_type x1))
+and copy_module_type :
+  Ast_412.Parsetree.module_type -> Ast_411.Parsetree.module_type =
+  fun
+    { Ast_412.Parsetree.pmty_desc = pmty_desc;
+      Ast_412.Parsetree.pmty_loc = pmty_loc;
+      Ast_412.Parsetree.pmty_attributes = pmty_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pmty_desc = (copy_module_type_desc pmty_desc);
+      Ast_411.Parsetree.pmty_loc = (copy_location pmty_loc);
+      Ast_411.Parsetree.pmty_attributes = (copy_attributes pmty_attributes)
+    }
+and copy_module_type_desc :
+  Ast_412.Parsetree.module_type_desc -> Ast_411.Parsetree.module_type_desc =
+  function
+  | Ast_412.Parsetree.Pmty_ident x0 ->
+      Ast_411.Parsetree.Pmty_ident (copy_loc copy_Longident_t x0)
+  | Ast_412.Parsetree.Pmty_signature x0 ->
+      Ast_411.Parsetree.Pmty_signature (copy_signature x0)
+  | Ast_412.Parsetree.Pmty_functor (x0, x1) ->
+      Ast_411.Parsetree.Pmty_functor
+        ((copy_functor_parameter x0), (copy_module_type x1))
+  | Ast_412.Parsetree.Pmty_with (x0, x1) ->
+      Ast_411.Parsetree.Pmty_with
+        ((copy_module_type x0), (List.map copy_with_constraint x1))
+  | Ast_412.Parsetree.Pmty_typeof x0 ->
+      Ast_411.Parsetree.Pmty_typeof (copy_module_expr x0)
+  | Ast_412.Parsetree.Pmty_extension x0 ->
+      Ast_411.Parsetree.Pmty_extension (copy_extension x0)
+  | Ast_412.Parsetree.Pmty_alias x0 ->
+      Ast_411.Parsetree.Pmty_alias (copy_loc copy_Longident_t x0)
+and copy_with_constraint :
+  Ast_412.Parsetree.with_constraint -> Ast_411.Parsetree.with_constraint =
+  function
+  | Ast_412.Parsetree.Pwith_type (x0, x1) ->
+      Ast_411.Parsetree.Pwith_type
+        ((copy_loc copy_Longident_t x0), (copy_type_declaration x1))
+  | Ast_412.Parsetree.Pwith_module (x0, x1) ->
+      Ast_411.Parsetree.Pwith_module
+        ((copy_loc copy_Longident_t x0), (copy_loc copy_Longident_t x1))
+  | Ast_412.Parsetree.Pwith_typesubst (x0, x1) ->
+      Ast_411.Parsetree.Pwith_typesubst
+        ((copy_loc copy_Longident_t x0), (copy_type_declaration x1))
+  | Ast_412.Parsetree.Pwith_modsubst (x0, x1) ->
+      Ast_411.Parsetree.Pwith_modsubst
+        ((copy_loc copy_Longident_t x0), (copy_loc copy_Longident_t x1))
+and copy_signature :
+  Ast_412.Parsetree.signature -> Ast_411.Parsetree.signature =
+  fun x -> List.map copy_signature_item x
+and copy_signature_item :
+  Ast_412.Parsetree.signature_item -> Ast_411.Parsetree.signature_item =
+  fun
+    { Ast_412.Parsetree.psig_desc = psig_desc;
+      Ast_412.Parsetree.psig_loc = psig_loc }
+    ->
+    {
+      Ast_411.Parsetree.psig_desc = (copy_signature_item_desc psig_desc);
+      Ast_411.Parsetree.psig_loc = (copy_location psig_loc)
+    }
+and copy_signature_item_desc :
+  Ast_412.Parsetree.signature_item_desc ->
+    Ast_411.Parsetree.signature_item_desc
+  =
+  function
+  | Ast_412.Parsetree.Psig_value x0 ->
+      Ast_411.Parsetree.Psig_value (copy_value_description x0)
+  | Ast_412.Parsetree.Psig_type (x0, x1) ->
+      Ast_411.Parsetree.Psig_type
+        ((copy_rec_flag x0), (List.map copy_type_declaration x1))
+  | Ast_412.Parsetree.Psig_typesubst x0 ->
+      Ast_411.Parsetree.Psig_typesubst (List.map copy_type_declaration x0)
+  | Ast_412.Parsetree.Psig_typext x0 ->
+      Ast_411.Parsetree.Psig_typext (copy_type_extension x0)
+  | Ast_412.Parsetree.Psig_exception x0 ->
+      Ast_411.Parsetree.Psig_exception (copy_type_exception x0)
+  | Ast_412.Parsetree.Psig_module x0 ->
+      Ast_411.Parsetree.Psig_module (copy_module_declaration x0)
+  | Ast_412.Parsetree.Psig_modsubst x0 ->
+      Ast_411.Parsetree.Psig_modsubst (copy_module_substitution x0)
+  | Ast_412.Parsetree.Psig_recmodule x0 ->
+      Ast_411.Parsetree.Psig_recmodule (List.map copy_module_declaration x0)
+  | Ast_412.Parsetree.Psig_modtype x0 ->
+      Ast_411.Parsetree.Psig_modtype (copy_module_type_declaration x0)
+  | Ast_412.Parsetree.Psig_open x0 ->
+      Ast_411.Parsetree.Psig_open (copy_open_description x0)
+  | Ast_412.Parsetree.Psig_include x0 ->
+      Ast_411.Parsetree.Psig_include (copy_include_description x0)
+  | Ast_412.Parsetree.Psig_class x0 ->
+      Ast_411.Parsetree.Psig_class (List.map copy_class_description x0)
+  | Ast_412.Parsetree.Psig_class_type x0 ->
+      Ast_411.Parsetree.Psig_class_type
+        (List.map copy_class_type_declaration x0)
+  | Ast_412.Parsetree.Psig_attribute x0 ->
+      Ast_411.Parsetree.Psig_attribute (copy_attribute x0)
+  | Ast_412.Parsetree.Psig_extension (x0, x1) ->
+      Ast_411.Parsetree.Psig_extension
+        ((copy_extension x0), (copy_attributes x1))
+and copy_class_type_declaration :
+  Ast_412.Parsetree.class_type_declaration ->
+    Ast_411.Parsetree.class_type_declaration
+  = fun x -> copy_class_infos copy_class_type x
+and copy_class_description :
+  Ast_412.Parsetree.class_description -> Ast_411.Parsetree.class_description
+  = fun x -> copy_class_infos copy_class_type x
+and copy_class_type :
+  Ast_412.Parsetree.class_type -> Ast_411.Parsetree.class_type =
+  fun
+    { Ast_412.Parsetree.pcty_desc = pcty_desc;
+      Ast_412.Parsetree.pcty_loc = pcty_loc;
+      Ast_412.Parsetree.pcty_attributes = pcty_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pcty_desc = (copy_class_type_desc pcty_desc);
+      Ast_411.Parsetree.pcty_loc = (copy_location pcty_loc);
+      Ast_411.Parsetree.pcty_attributes = (copy_attributes pcty_attributes)
+    }
+and copy_class_type_desc :
+  Ast_412.Parsetree.class_type_desc -> Ast_411.Parsetree.class_type_desc =
+  function
+  | Ast_412.Parsetree.Pcty_constr (x0, x1) ->
+      Ast_411.Parsetree.Pcty_constr
+        ((copy_loc copy_Longident_t x0), (List.map copy_core_type x1))
+  | Ast_412.Parsetree.Pcty_signature x0 ->
+      Ast_411.Parsetree.Pcty_signature (copy_class_signature x0)
+  | Ast_412.Parsetree.Pcty_arrow (x0, x1, x2) ->
+      Ast_411.Parsetree.Pcty_arrow
+        ((copy_arg_label x0), (copy_core_type x1), (copy_class_type x2))
+  | Ast_412.Parsetree.Pcty_extension x0 ->
+      Ast_411.Parsetree.Pcty_extension (copy_extension x0)
+  | Ast_412.Parsetree.Pcty_open (x0, x1) ->
+      Ast_411.Parsetree.Pcty_open
+        ((copy_open_description x0), (copy_class_type x1))
+and copy_class_signature :
+  Ast_412.Parsetree.class_signature -> Ast_411.Parsetree.class_signature =
+  fun
+    { Ast_412.Parsetree.pcsig_self = pcsig_self;
+      Ast_412.Parsetree.pcsig_fields = pcsig_fields }
+    ->
+    {
+      Ast_411.Parsetree.pcsig_self = (copy_core_type pcsig_self);
+      Ast_411.Parsetree.pcsig_fields =
+        (List.map copy_class_type_field pcsig_fields)
+    }
+and copy_class_type_field :
+  Ast_412.Parsetree.class_type_field -> Ast_411.Parsetree.class_type_field =
+  fun
+    { Ast_412.Parsetree.pctf_desc = pctf_desc;
+      Ast_412.Parsetree.pctf_loc = pctf_loc;
+      Ast_412.Parsetree.pctf_attributes = pctf_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pctf_desc = (copy_class_type_field_desc pctf_desc);
+      Ast_411.Parsetree.pctf_loc = (copy_location pctf_loc);
+      Ast_411.Parsetree.pctf_attributes = (copy_attributes pctf_attributes)
+    }
+and copy_class_type_field_desc :
+  Ast_412.Parsetree.class_type_field_desc ->
+    Ast_411.Parsetree.class_type_field_desc
+  =
+  function
+  | Ast_412.Parsetree.Pctf_inherit x0 ->
+      Ast_411.Parsetree.Pctf_inherit (copy_class_type x0)
+  | Ast_412.Parsetree.Pctf_val x0 ->
+      Ast_411.Parsetree.Pctf_val
+        (let (x0, x1, x2, x3) = x0 in
+         ((copy_loc copy_label x0), (copy_mutable_flag x1),
+           (copy_virtual_flag x2), (copy_core_type x3)))
+  | Ast_412.Parsetree.Pctf_method x0 ->
+      Ast_411.Parsetree.Pctf_method
+        (let (x0, x1, x2, x3) = x0 in
+         ((copy_loc copy_label x0), (copy_private_flag x1),
+           (copy_virtual_flag x2), (copy_core_type x3)))
+  | Ast_412.Parsetree.Pctf_constraint x0 ->
+      Ast_411.Parsetree.Pctf_constraint
+        (let (x0, x1) = x0 in ((copy_core_type x0), (copy_core_type x1)))
+  | Ast_412.Parsetree.Pctf_attribute x0 ->
+      Ast_411.Parsetree.Pctf_attribute (copy_attribute x0)
+  | Ast_412.Parsetree.Pctf_extension x0 ->
+      Ast_411.Parsetree.Pctf_extension (copy_extension x0)
+and copy_extension :
+  Ast_412.Parsetree.extension -> Ast_411.Parsetree.extension =
+  fun x ->
+    let (x0, x1) = x in ((copy_loc (fun x -> x) x0), (copy_payload x1))
+and copy_class_infos :
+  'f0 'g0 .
+    ('f0 -> 'g0) ->
+      'f0 Ast_412.Parsetree.class_infos -> 'g0 Ast_411.Parsetree.class_infos
+  =
+  fun f0 ->
+    fun
+      { Ast_412.Parsetree.pci_virt = pci_virt;
+        Ast_412.Parsetree.pci_params = pci_params;
+        Ast_412.Parsetree.pci_name = pci_name;
+        Ast_412.Parsetree.pci_expr = pci_expr;
+        Ast_412.Parsetree.pci_loc = pci_loc;
+        Ast_412.Parsetree.pci_attributes = pci_attributes }
+      ->
+      {
+        Ast_411.Parsetree.pci_virt = (copy_virtual_flag pci_virt);
+        Ast_411.Parsetree.pci_params =
+          (List.map
+             (fun x ->
+                let (x0, x1) = x in
+                ((copy_core_type x0),
+                  (let (x0, x1) = x1 in
+                   ((copy_variance x0), (copy_injectivity x1))))) pci_params);
+        Ast_411.Parsetree.pci_name = (copy_loc (fun x -> x) pci_name);
+        Ast_411.Parsetree.pci_expr = (f0 pci_expr);
+        Ast_411.Parsetree.pci_loc = (copy_location pci_loc);
+        Ast_411.Parsetree.pci_attributes = (copy_attributes pci_attributes)
+      }
+and copy_virtual_flag :
+  Ast_412.Asttypes.virtual_flag -> Ast_411.Asttypes.virtual_flag =
+  function
+  | Ast_412.Asttypes.Virtual -> Ast_411.Asttypes.Virtual
+  | Ast_412.Asttypes.Concrete -> Ast_411.Asttypes.Concrete
+and copy_include_description :
+  Ast_412.Parsetree.include_description ->
+    Ast_411.Parsetree.include_description
+  = fun x -> copy_include_infos copy_module_type x
+and copy_include_infos :
+  'f0 'g0 .
+    ('f0 -> 'g0) ->
+      'f0 Ast_412.Parsetree.include_infos ->
+        'g0 Ast_411.Parsetree.include_infos
+  =
+  fun f0 ->
+    fun
+      { Ast_412.Parsetree.pincl_mod = pincl_mod;
+        Ast_412.Parsetree.pincl_loc = pincl_loc;
+        Ast_412.Parsetree.pincl_attributes = pincl_attributes }
+      ->
+      {
+        Ast_411.Parsetree.pincl_mod = (f0 pincl_mod);
+        Ast_411.Parsetree.pincl_loc = (copy_location pincl_loc);
+        Ast_411.Parsetree.pincl_attributes =
+          (copy_attributes pincl_attributes)
+      }
+and copy_open_description :
+  Ast_412.Parsetree.open_description -> Ast_411.Parsetree.open_description =
+  fun x -> copy_open_infos (fun x -> copy_loc copy_Longident_t x) x
+and copy_open_infos :
+  'f0 'g0 .
+    ('f0 -> 'g0) ->
+      'f0 Ast_412.Parsetree.open_infos -> 'g0 Ast_411.Parsetree.open_infos
+  =
+  fun f0 ->
+    fun
+      { Ast_412.Parsetree.popen_expr = popen_expr;
+        Ast_412.Parsetree.popen_override = popen_override;
+        Ast_412.Parsetree.popen_loc = popen_loc;
+        Ast_412.Parsetree.popen_attributes = popen_attributes }
+      ->
+      {
+        Ast_411.Parsetree.popen_expr = (f0 popen_expr);
+        Ast_411.Parsetree.popen_override =
+          (copy_override_flag popen_override);
+        Ast_411.Parsetree.popen_loc = (copy_location popen_loc);
+        Ast_411.Parsetree.popen_attributes =
+          (copy_attributes popen_attributes)
+      }
+and copy_override_flag :
+  Ast_412.Asttypes.override_flag -> Ast_411.Asttypes.override_flag =
+  function
+  | Ast_412.Asttypes.Override -> Ast_411.Asttypes.Override
+  | Ast_412.Asttypes.Fresh -> Ast_411.Asttypes.Fresh
+and copy_module_type_declaration :
+  Ast_412.Parsetree.module_type_declaration ->
+    Ast_411.Parsetree.module_type_declaration
+  =
+  fun
+    { Ast_412.Parsetree.pmtd_name = pmtd_name;
+      Ast_412.Parsetree.pmtd_type = pmtd_type;
+      Ast_412.Parsetree.pmtd_attributes = pmtd_attributes;
+      Ast_412.Parsetree.pmtd_loc = pmtd_loc }
+    ->
+    {
+      Ast_411.Parsetree.pmtd_name = (copy_loc (fun x -> x) pmtd_name);
+      Ast_411.Parsetree.pmtd_type = (Option.map copy_module_type pmtd_type);
+      Ast_411.Parsetree.pmtd_attributes = (copy_attributes pmtd_attributes);
+      Ast_411.Parsetree.pmtd_loc = (copy_location pmtd_loc)
+    }
+and copy_module_substitution :
+  Ast_412.Parsetree.module_substitution ->
+    Ast_411.Parsetree.module_substitution
+  =
+  fun
+    { Ast_412.Parsetree.pms_name = pms_name;
+      Ast_412.Parsetree.pms_manifest = pms_manifest;
+      Ast_412.Parsetree.pms_attributes = pms_attributes;
+      Ast_412.Parsetree.pms_loc = pms_loc }
+    ->
+    {
+      Ast_411.Parsetree.pms_name = (copy_loc (fun x -> x) pms_name);
+      Ast_411.Parsetree.pms_manifest =
+        (copy_loc copy_Longident_t pms_manifest);
+      Ast_411.Parsetree.pms_attributes = (copy_attributes pms_attributes);
+      Ast_411.Parsetree.pms_loc = (copy_location pms_loc)
+    }
+and copy_module_declaration :
+  Ast_412.Parsetree.module_declaration ->
+    Ast_411.Parsetree.module_declaration
+  =
+  fun
+    { Ast_412.Parsetree.pmd_name = pmd_name;
+      Ast_412.Parsetree.pmd_type = pmd_type;
+      Ast_412.Parsetree.pmd_attributes = pmd_attributes;
+      Ast_412.Parsetree.pmd_loc = pmd_loc }
+    ->
+    {
+      Ast_411.Parsetree.pmd_name =
+        (copy_loc (fun x -> Option.map (fun x -> x) x) pmd_name);
+      Ast_411.Parsetree.pmd_type = (copy_module_type pmd_type);
+      Ast_411.Parsetree.pmd_attributes = (copy_attributes pmd_attributes);
+      Ast_411.Parsetree.pmd_loc = (copy_location pmd_loc)
+    }
+and copy_type_exception :
+  Ast_412.Parsetree.type_exception -> Ast_411.Parsetree.type_exception =
+  fun
+    { Ast_412.Parsetree.ptyexn_constructor = ptyexn_constructor;
+      Ast_412.Parsetree.ptyexn_loc = ptyexn_loc;
+      Ast_412.Parsetree.ptyexn_attributes = ptyexn_attributes }
+    ->
+    {
+      Ast_411.Parsetree.ptyexn_constructor =
+        (copy_extension_constructor ptyexn_constructor);
+      Ast_411.Parsetree.ptyexn_loc = (copy_location ptyexn_loc);
+      Ast_411.Parsetree.ptyexn_attributes =
+        (copy_attributes ptyexn_attributes)
+    }
+and copy_type_extension :
+  Ast_412.Parsetree.type_extension -> Ast_411.Parsetree.type_extension =
+  fun
+    { Ast_412.Parsetree.ptyext_path = ptyext_path;
+      Ast_412.Parsetree.ptyext_params = ptyext_params;
+      Ast_412.Parsetree.ptyext_constructors = ptyext_constructors;
+      Ast_412.Parsetree.ptyext_private = ptyext_private;
+      Ast_412.Parsetree.ptyext_loc = ptyext_loc;
+      Ast_412.Parsetree.ptyext_attributes = ptyext_attributes }
+    ->
+    {
+      Ast_411.Parsetree.ptyext_path = (copy_loc copy_Longident_t ptyext_path);
+      Ast_411.Parsetree.ptyext_params =
+        (List.map
+           (fun x ->
+              let (x0, x1) = x in
+              ((copy_core_type x0),
+                (let (x0, x1) = x1 in
+                 ((copy_variance x0), (copy_injectivity x1))))) ptyext_params);
+      Ast_411.Parsetree.ptyext_constructors =
+        (List.map copy_extension_constructor ptyext_constructors);
+      Ast_411.Parsetree.ptyext_private = (copy_private_flag ptyext_private);
+      Ast_411.Parsetree.ptyext_loc = (copy_location ptyext_loc);
+      Ast_411.Parsetree.ptyext_attributes =
+        (copy_attributes ptyext_attributes)
+    }
+and copy_extension_constructor :
+  Ast_412.Parsetree.extension_constructor ->
+    Ast_411.Parsetree.extension_constructor
+  =
+  fun
+    { Ast_412.Parsetree.pext_name = pext_name;
+      Ast_412.Parsetree.pext_kind = pext_kind;
+      Ast_412.Parsetree.pext_loc = pext_loc;
+      Ast_412.Parsetree.pext_attributes = pext_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pext_name = (copy_loc (fun x -> x) pext_name);
+      Ast_411.Parsetree.pext_kind =
+        (copy_extension_constructor_kind pext_kind);
+      Ast_411.Parsetree.pext_loc = (copy_location pext_loc);
+      Ast_411.Parsetree.pext_attributes = (copy_attributes pext_attributes)
+    }
+and copy_extension_constructor_kind :
+  Ast_412.Parsetree.extension_constructor_kind ->
+    Ast_411.Parsetree.extension_constructor_kind
+  =
+  function
+  | Ast_412.Parsetree.Pext_decl (x0, x1) ->
+      Ast_411.Parsetree.Pext_decl
+        ((copy_constructor_arguments x0), (Option.map copy_core_type x1))
+  | Ast_412.Parsetree.Pext_rebind x0 ->
+      Ast_411.Parsetree.Pext_rebind (copy_loc copy_Longident_t x0)
+and copy_type_declaration :
+  Ast_412.Parsetree.type_declaration -> Ast_411.Parsetree.type_declaration =
+  fun
+    { Ast_412.Parsetree.ptype_name = ptype_name;
+      Ast_412.Parsetree.ptype_params = ptype_params;
+      Ast_412.Parsetree.ptype_cstrs = ptype_cstrs;
+      Ast_412.Parsetree.ptype_kind = ptype_kind;
+      Ast_412.Parsetree.ptype_private = ptype_private;
+      Ast_412.Parsetree.ptype_manifest = ptype_manifest;
+      Ast_412.Parsetree.ptype_attributes = ptype_attributes;
+      Ast_412.Parsetree.ptype_loc = ptype_loc }
+    ->
+    {
+      Ast_411.Parsetree.ptype_name = (copy_loc (fun x -> x) ptype_name);
+      Ast_411.Parsetree.ptype_params =
+        (List.map
+           (fun x ->
+              let (x0, x1) = x in
+              ((copy_core_type x0),
+                (let (x0, x1) = x1 in
+                 ((copy_variance x0), (copy_injectivity x1))))) ptype_params);
+      Ast_411.Parsetree.ptype_cstrs =
+        (List.map
+           (fun x ->
+              let (x0, x1, x2) = x in
+              ((copy_core_type x0), (copy_core_type x1), (copy_location x2)))
+           ptype_cstrs);
+      Ast_411.Parsetree.ptype_kind = (copy_type_kind ptype_kind);
+      Ast_411.Parsetree.ptype_private = (copy_private_flag ptype_private);
+      Ast_411.Parsetree.ptype_manifest =
+        (Option.map copy_core_type ptype_manifest);
+      Ast_411.Parsetree.ptype_attributes = (copy_attributes ptype_attributes);
+      Ast_411.Parsetree.ptype_loc = (copy_location ptype_loc)
+    }
+and copy_private_flag :
+  Ast_412.Asttypes.private_flag -> Ast_411.Asttypes.private_flag =
+  function
+  | Ast_412.Asttypes.Private -> Ast_411.Asttypes.Private
+  | Ast_412.Asttypes.Public -> Ast_411.Asttypes.Public
+and copy_type_kind :
+  Ast_412.Parsetree.type_kind -> Ast_411.Parsetree.type_kind =
+  function
+  | Ast_412.Parsetree.Ptype_abstract -> Ast_411.Parsetree.Ptype_abstract
+  | Ast_412.Parsetree.Ptype_variant x0 ->
+      Ast_411.Parsetree.Ptype_variant
+        (List.map copy_constructor_declaration x0)
+  | Ast_412.Parsetree.Ptype_record x0 ->
+      Ast_411.Parsetree.Ptype_record (List.map copy_label_declaration x0)
+  | Ast_412.Parsetree.Ptype_open -> Ast_411.Parsetree.Ptype_open
+and copy_constructor_declaration :
+  Ast_412.Parsetree.constructor_declaration ->
+    Ast_411.Parsetree.constructor_declaration
+  =
+  fun
+    { Ast_412.Parsetree.pcd_name = pcd_name;
+      Ast_412.Parsetree.pcd_args = pcd_args;
+      Ast_412.Parsetree.pcd_res = pcd_res;
+      Ast_412.Parsetree.pcd_loc = pcd_loc;
+      Ast_412.Parsetree.pcd_attributes = pcd_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pcd_name = (copy_loc (fun x -> x) pcd_name);
+      Ast_411.Parsetree.pcd_args = (copy_constructor_arguments pcd_args);
+      Ast_411.Parsetree.pcd_res = (Option.map copy_core_type pcd_res);
+      Ast_411.Parsetree.pcd_loc = (copy_location pcd_loc);
+      Ast_411.Parsetree.pcd_attributes = (copy_attributes pcd_attributes)
+    }
+and copy_constructor_arguments :
+  Ast_412.Parsetree.constructor_arguments ->
+    Ast_411.Parsetree.constructor_arguments
+  =
+  function
+  | Ast_412.Parsetree.Pcstr_tuple x0 ->
+      Ast_411.Parsetree.Pcstr_tuple (List.map copy_core_type x0)
+  | Ast_412.Parsetree.Pcstr_record x0 ->
+      Ast_411.Parsetree.Pcstr_record (List.map copy_label_declaration x0)
+and copy_label_declaration :
+  Ast_412.Parsetree.label_declaration -> Ast_411.Parsetree.label_declaration
+  =
+  fun
+    { Ast_412.Parsetree.pld_name = pld_name;
+      Ast_412.Parsetree.pld_mutable = pld_mutable;
+      Ast_412.Parsetree.pld_type = pld_type;
+      Ast_412.Parsetree.pld_loc = pld_loc;
+      Ast_412.Parsetree.pld_attributes = pld_attributes }
+    ->
+    {
+      Ast_411.Parsetree.pld_name = (copy_loc (fun x -> x) pld_name);
+      Ast_411.Parsetree.pld_mutable = (copy_mutable_flag pld_mutable);
+      Ast_411.Parsetree.pld_type = (copy_core_type pld_type);
+      Ast_411.Parsetree.pld_loc = (copy_location pld_loc);
+      Ast_411.Parsetree.pld_attributes = (copy_attributes pld_attributes)
+    }
+and copy_mutable_flag :
+  Ast_412.Asttypes.mutable_flag -> Ast_411.Asttypes.mutable_flag =
+  function
+  | Ast_412.Asttypes.Immutable -> Ast_411.Asttypes.Immutable
+  | Ast_412.Asttypes.Mutable -> Ast_411.Asttypes.Mutable
+and copy_injectivity :
+  Ast_412.Asttypes.injectivity -> Ast_411.Asttypes.injectivity =
+  function
+  | Ast_412.Asttypes.Injective -> Ast_411.Asttypes.Injective
+  | Ast_412.Asttypes.NoInjectivity -> Ast_411.Asttypes.NoInjectivity
+and copy_variance : Ast_412.Asttypes.variance -> Ast_411.Asttypes.variance =
+  function
+  | Ast_412.Asttypes.Covariant -> Ast_411.Asttypes.Covariant
+  | Ast_412.Asttypes.Contravariant -> Ast_411.Asttypes.Contravariant
+  | Ast_412.Asttypes.NoVariance -> Ast_411.Asttypes.NoVariance
+and copy_value_description :
+  Ast_412.Parsetree.value_description -> Ast_411.Parsetree.value_description
+  =
+  fun
+    { Ast_412.Parsetree.pval_name = pval_name;
+      Ast_412.Parsetree.pval_type = pval_type;
+      Ast_412.Parsetree.pval_prim = pval_prim;
+      Ast_412.Parsetree.pval_attributes = pval_attributes;
+      Ast_412.Parsetree.pval_loc = pval_loc }
+    ->
+    {
+      Ast_411.Parsetree.pval_name = (copy_loc (fun x -> x) pval_name);
+      Ast_411.Parsetree.pval_type = (copy_core_type pval_type);
+      Ast_411.Parsetree.pval_prim = (List.map (fun x -> x) pval_prim);
+      Ast_411.Parsetree.pval_attributes = (copy_attributes pval_attributes);
+      Ast_411.Parsetree.pval_loc = (copy_location pval_loc)
+    }
+and copy_object_field_desc :
+  Ast_412.Parsetree.object_field_desc -> Ast_411.Parsetree.object_field_desc
+  =
+  function
+  | Ast_412.Parsetree.Otag (x0, x1) ->
+      Ast_411.Parsetree.Otag ((copy_loc copy_label x0), (copy_core_type x1))
+  | Ast_412.Parsetree.Oinherit x0 ->
+      Ast_411.Parsetree.Oinherit (copy_core_type x0)
+and copy_arg_label : Ast_412.Asttypes.arg_label -> Ast_411.Asttypes.arg_label
+  =
+  function
+  | Ast_412.Asttypes.Nolabel -> Ast_411.Asttypes.Nolabel
+  | Ast_412.Asttypes.Labelled x0 -> Ast_411.Asttypes.Labelled x0
+  | Ast_412.Asttypes.Optional x0 -> Ast_411.Asttypes.Optional x0
+and copy_closed_flag :
+  Ast_412.Asttypes.closed_flag -> Ast_411.Asttypes.closed_flag =
+  function
+  | Ast_412.Asttypes.Closed -> Ast_411.Asttypes.Closed
+  | Ast_412.Asttypes.Open -> Ast_411.Asttypes.Open
+and copy_label : Ast_412.Asttypes.label -> Ast_411.Asttypes.label =
+  fun x -> x
+and copy_rec_flag : Ast_412.Asttypes.rec_flag -> Ast_411.Asttypes.rec_flag =
+  function
+  | Ast_412.Asttypes.Nonrecursive -> Ast_411.Asttypes.Nonrecursive
+  | Ast_412.Asttypes.Recursive -> Ast_411.Asttypes.Recursive
+and copy_constant : Ast_412.Parsetree.constant -> Ast_411.Parsetree.constant
+  =
+  function
+  | Ast_412.Parsetree.Pconst_integer (x0, x1) ->
+      Ast_411.Parsetree.Pconst_integer (x0, (Option.map (fun x -> x) x1))
+  | Ast_412.Parsetree.Pconst_char x0 -> Ast_411.Parsetree.Pconst_char x0
+  | Ast_412.Parsetree.Pconst_string (x0, x1, x2) ->
+      Ast_411.Parsetree.Pconst_string
+        (x0, (copy_location x1), (Option.map (fun x -> x) x2))
+  | Ast_412.Parsetree.Pconst_float (x0, x1) ->
+      Ast_411.Parsetree.Pconst_float (x0, (Option.map (fun x -> x) x1))
+and copy_Longident_t : Longident.t -> Longident.t =
+  function
+  | Longident.Lident x0 -> Longident.Lident x0
+  | Longident.Ldot (x0, x1) -> Longident.Ldot ((copy_Longident_t x0), x1)
+  | Longident.Lapply (x0, x1) ->
+      Longident.Lapply ((copy_Longident_t x0), (copy_Longident_t x1))
+and copy_loc :
+  'f0 'g0 .
+    ('f0 -> 'g0) -> 'f0 Ast_412.Asttypes.loc -> 'g0 Ast_411.Asttypes.loc
+  =
+  fun f0 ->
+    fun { Ast_412.Asttypes.txt = txt; Ast_412.Asttypes.loc = loc } ->
+      {
+        Ast_411.Asttypes.txt = (f0 txt);
+        Ast_411.Asttypes.loc = (copy_location loc)
+      }
+and copy_location : Location.t -> Location.t =
+  fun
+    { Location.loc_start = loc_start; Location.loc_end = loc_end;
+      Location.loc_ghost = loc_ghost }
+    ->
+    {
+      Location.loc_start = (copy_position loc_start);
+      Location.loc_end = (copy_position loc_end);
+      Location.loc_ghost = loc_ghost
+    }
+and copy_position : Stdlib.Lexing.position -> Stdlib.Lexing.position =
+  fun
+    { Stdlib.Lexing.pos_fname = pos_fname; Stdlib.Lexing.pos_lnum = pos_lnum;
+      Stdlib.Lexing.pos_bol = pos_bol; Stdlib.Lexing.pos_cnum = pos_cnum }
+    ->
+    {
+      Stdlib.Lexing.pos_fname = pos_fname;
+      Stdlib.Lexing.pos_lnum = pos_lnum;
+      Stdlib.Lexing.pos_bol = pos_bol;
+      Stdlib.Lexing.pos_cnum = pos_cnum
+    }

--- a/src/migrate_412_411.ml
+++ b/src/migrate_412_411.ml
@@ -832,8 +832,8 @@ and copy_class_infos :
              (fun x ->
                 let (x0, x1) = x in
                 ((copy_core_type x0),
-                  (let (x0, x1) = x1 in
-                   ((copy_variance x0), (copy_injectivity x1))))) pci_params);
+                  (let (x0, _) = x1 in
+                   (copy_variance x0)))) pci_params);
         Ast_411.Parsetree.pci_name = (copy_loc (fun x -> x) pci_name);
         Ast_411.Parsetree.pci_expr = (f0 pci_expr);
         Ast_411.Parsetree.pci_loc = (copy_location pci_loc);
@@ -975,8 +975,8 @@ and copy_type_extension :
            (fun x ->
               let (x0, x1) = x in
               ((copy_core_type x0),
-                (let (x0, x1) = x1 in
-                 ((copy_variance x0), (copy_injectivity x1))))) ptyext_params);
+                (let (x0, _) = x1 in
+                 (copy_variance x0)))) ptyext_params);
       Ast_411.Parsetree.ptyext_constructors =
         (List.map copy_extension_constructor ptyext_constructors);
       Ast_411.Parsetree.ptyext_private = (copy_private_flag ptyext_private);
@@ -1030,8 +1030,8 @@ and copy_type_declaration :
            (fun x ->
               let (x0, x1) = x in
               ((copy_core_type x0),
-                (let (x0, x1) = x1 in
-                 ((copy_variance x0), (copy_injectivity x1))))) ptype_params);
+                (let (x0, _) = x1 in
+                 (copy_variance x0)))) ptype_params);
       Ast_411.Parsetree.ptype_cstrs =
         (List.map
            (fun x ->
@@ -1109,16 +1109,11 @@ and copy_mutable_flag :
   function
   | Ast_412.Asttypes.Immutable -> Ast_411.Asttypes.Immutable
   | Ast_412.Asttypes.Mutable -> Ast_411.Asttypes.Mutable
-and copy_injectivity :
-  Ast_412.Asttypes.injectivity -> Ast_411.Asttypes.injectivity =
-  function
-  | Ast_412.Asttypes.Injective -> Ast_411.Asttypes.Injective
-  | Ast_412.Asttypes.NoInjectivity -> Ast_411.Asttypes.NoInjectivity
 and copy_variance : Ast_412.Asttypes.variance -> Ast_411.Asttypes.variance =
   function
   | Ast_412.Asttypes.Covariant -> Ast_411.Asttypes.Covariant
   | Ast_412.Asttypes.Contravariant -> Ast_411.Asttypes.Contravariant
-  | Ast_412.Asttypes.NoVariance -> Ast_411.Asttypes.NoVariance
+  | Ast_412.Asttypes.NoVariance -> Ast_411.Asttypes.Invariant
 and copy_value_description :
   Ast_412.Parsetree.value_description -> Ast_411.Parsetree.value_description
   =

--- a/src/migrate_412_411.ml
+++ b/src/migrate_412_411.ml
@@ -1182,5 +1182,3 @@ and copy_loc :
       }
 and copy_location : Location.t -> Location.t =
   fun x -> x
-and copy_position : Stdlib.Lexing.position -> Stdlib.Lexing.position =
-  fun x -> x

--- a/src/migrate_412_411.ml
+++ b/src/migrate_412_411.ml
@@ -312,7 +312,7 @@ and copy_core_type :
     }
 and copy_location_stack :
   Ast_412.Parsetree.location_stack -> Ast_411.Parsetree.location_stack =
-  fun x -> List.map copy_location x
+  fun x -> x
 and copy_core_type_desc :
   Ast_412.Parsetree.core_type_desc -> Ast_411.Parsetree.core_type_desc =
   function
@@ -1169,11 +1169,7 @@ and copy_constant : Ast_412.Parsetree.constant -> Ast_411.Parsetree.constant
   | Ast_412.Parsetree.Pconst_float (x0, x1) ->
       Ast_411.Parsetree.Pconst_float (x0, (Option.map (fun x -> x) x1))
 and copy_Longident_t : Longident.t -> Longident.t =
-  function
-  | Longident.Lident x0 -> Longident.Lident x0
-  | Longident.Ldot (x0, x1) -> Longident.Ldot ((copy_Longident_t x0), x1)
-  | Longident.Lapply (x0, x1) ->
-      Longident.Lapply ((copy_Longident_t x0), (copy_Longident_t x1))
+  fun x -> x
 and copy_loc :
   'f0 'g0 .
     ('f0 -> 'g0) -> 'f0 Ast_412.Asttypes.loc -> 'g0 Ast_411.Asttypes.loc
@@ -1185,23 +1181,6 @@ and copy_loc :
         Ast_411.Asttypes.loc = (copy_location loc)
       }
 and copy_location : Location.t -> Location.t =
-  fun
-    { Location.loc_start = loc_start; Location.loc_end = loc_end;
-      Location.loc_ghost = loc_ghost }
-    ->
-    {
-      Location.loc_start = (copy_position loc_start);
-      Location.loc_end = (copy_position loc_end);
-      Location.loc_ghost = loc_ghost
-    }
+  fun x -> x
 and copy_position : Stdlib.Lexing.position -> Stdlib.Lexing.position =
-  fun
-    { Stdlib.Lexing.pos_fname = pos_fname; Stdlib.Lexing.pos_lnum = pos_lnum;
-      Stdlib.Lexing.pos_bol = pos_bol; Stdlib.Lexing.pos_cnum = pos_cnum }
-    ->
-    {
-      Stdlib.Lexing.pos_fname = pos_fname;
-      Stdlib.Lexing.pos_lnum = pos_lnum;
-      Stdlib.Lexing.pos_bol = pos_bol;
-      Stdlib.Lexing.pos_cnum = pos_cnum
-    }
+  fun x -> x

--- a/src/migrate_412_411.ml
+++ b/src/migrate_412_411.ml
@@ -1,3 +1,4 @@
+open Stdlib0
 module From = Ast_412
 module To = Ast_411
 let rec copy_toplevel_phrase :

--- a/src/migrate_parsetree.ml
+++ b/src/migrate_parsetree.ml
@@ -36,6 +36,7 @@ module Ast_408 = Ast_408
 module Ast_409 = Ast_409
 module Ast_410 = Ast_410
 module Ast_411 = Ast_411
+module Ast_412 = Ast_412
 (*$*)
 
 (* Manual migration between versions *)
@@ -61,6 +62,8 @@ module Migrate_409_410 = Migrate_409_410
 module Migrate_410_409 = Migrate_410_409
 module Migrate_410_411 = Migrate_410_411
 module Migrate_411_410 = Migrate_411_410
+module Migrate_411_412 = Migrate_411_412
+module Migrate_412_411 = Migrate_412_411
 (*$*)
 
 (* Aliases for compiler-libs modules that might be shadowed *)


### PR DESCRIPTION
Added support for 4.12 compiler to ocaml-migrate-parsetree. Updated instructions in README for adding new versions.