### PR TITLE
Forbid ocp-ident to take the system preset to indent comments

### DIFF
--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,2 +1,3 @@
+normal
 match_clause=4
 strict_with=auto


### PR DESCRIPTION
Apparently the current behaviour of ocp-indent is such that if no preset is given, it will fallback to the system preset (e.g. from ~/.ocp/ocp-indent.conf). This simplifies porting ocaml-migrate-parsetree to a new version of OCaml quite a bit.

@AltGr is this expected?