### PR TITLE
Improve the instructions in the README to add a new version of the OCaml compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ diff. Port the old adjustments to the new file as required.
 Add migration functions. In the commands below, set $OLD and $NEW to the
 appropriate version numbers, e.g. 408 and 409:
 - Manually compile the asts (`ocamlc -c src/ast_{$NEW,$OLD}.ml -I +compiler-libs -I _build/default/src/.migrate_parsetree.objs/byte/`)
-- Using `tools/gencopy.exe` (`dune build tools/gencopy.exe`), generate copy code to and from previous version (assuming it is 408):
+- Using `tools/gencopy.exe` (`dune build tools/gencopy.exe`), generate copy code to and from previous version:
 ```
 _build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_${NEW}:Ast_${OLD} Ast_${NEW}.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${NEW}_${OLD}.ml
 _build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_${OLD}:Ast_${NEW} Ast_${OLD}.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${OLD}_${NEW}.ml

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ appropriate version numbers, e.g. 408 and 409:
 - Manually compile the asts (`ocamlc -c src/ast_{$NEW,$OLD}.ml -I +compiler-libs -I _build/default/src/.migrate_parsetree.objs/byte/`)
 - Using `tools/gencopy.exe` (`dune build tools/gencopy.exe`), generate copy code to and from previous version (assuming it is 408):
 ```
-_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$NEW:Ast_$OLD Ast_$NEW.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${NEW}_${OLD}.ml
-_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_$OLD:Ast_$NEW Ast_$OLD.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${OLD}_${NEW}.ml
+_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_${NEW}:Ast_${OLD} Ast_${NEW}.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${NEW}_${OLD}.ml
+_build/default/tools/gencopy.exe -I . -I src/ -I +compiler-libs -map Ast_${OLD}:Ast_${NEW} Ast_${OLD}.Parsetree.{expression,pattern,core_type,toplevel_phrase} > src/migrate_${OLD}_${NEW}.ml
 ```
 - Fix the generated code by implementing new cases
 


### PR DESCRIPTION
~The instructions did not explicitly said that `expression,pattern,core_type,toplevel_phrase` needed to be changed and I kept getting weird failures when running gencopy.exe. Thanks to @pitag-ha for realizing that it should be replaced by the types that changed between the two versions.~

~Hopefully the wording is clear enough with that.~

EDIT: Mmh, nevermind.