### PR TITLE
Deprecate the project

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+unreleased
+------------------------
+
+- Deprecate the project in favor of ppxlib (#126, @pitag-ha)
+
+
 2.4.0 2022-06-17 Valencia
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **DEPRECATED** This package is deprecated. Please, use
 [ppxlib](https://github.com/ocaml-ppx/ppxlib) instead.
+See https://ocaml.org/changelog/2023-10-23-omp-deprecation.
 
 Convert OCaml parsetrees between different major versions
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # OCaml-migrate-parsetree
+[Deprecated] This package is deprecated. Please, use
+[ppxlib](https://github.com/ocaml-ppx/ppxlib) instead.
+
 Convert OCaml parsetrees between different major versions
 
 This library converts between parsetrees of different OCaml versions.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # OCaml-migrate-parsetree
-[Deprecated] This package is deprecated. Please, use
+
+**DEPRECATED** This package is deprecated. Please, use
 [ppxlib](https://github.com/ocaml-ppx/ppxlib) instead.
 
 Convert OCaml parsetrees between different major versions

--- a/ocaml-migrate-parsetree.opam
+++ b/ocaml-migrate-parsetree.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+flags: deprecated
 maintainer: "frederic.bour@lakaban.net"
 authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
@@ -22,6 +23,8 @@ conflicts: [
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """
+Deprecated. Please, use Ppxlib instead.
+
 Convert OCaml parsetrees between different versions
 
 This library converts parsetrees, outcometree and ast mappers between


### PR DESCRIPTION
I'm deprecating the project.

We've had the impression that the community is behind it by observing strongly decreased interest in latest compiler support for a while. Now, I've tried to confirm that impression by writing a [discuss post](https://discuss.ocaml.org/t/rfc-deprecating-ocaml-migrate-parsetree-in-favor-of-ppxlib-also-as-a-platform-tool/13240) about deprecating it giving quite some context and asking for potential feedback. Not that many people have read it (< 300 people), but out of the ones that have, nobody has objected or commented :)

Deprecating it, also means that we won't add OCaml 5.1 support or newer anymore.